### PR TITLE
修复最大化时的窗口高度

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -218,9 +218,13 @@ public partial class App : Application
         if (displayArea != null)
         {
             var rect = GetRenderRect(displayArea, hwnd);
+            var scaleFactor = Windows.Win32.PInvoke.GetDpiForWindow(new Windows.Win32.Foundation.HWND(hwnd)) / 96d;
             _window.MinWidth = 500;
             _window.MaxWidth = 500;
             _window.MinHeight = 400;
+
+            var maxHeight = displayArea.WorkArea.Height / scaleFactor;
+            _window.MaxHeight = maxHeight < 400 ? 400 : maxHeight;
             _window.AppWindow.MoveAndResize(rect);
         }
     }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #64 

修复最大化时窗口高度超出范围的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

点击最大化按钮后，窗口的高度与屏幕高度一致，导致底部被任务栏遮挡

## 新的行为是什么？

修复这个问题，限制了窗口的最大高度

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新

