### PR TITLE
支持播放窗口大小记忆

### DIFF
--- a/src/App/Forms/PlayerWindow.xaml.cs
+++ b/src/App/Forms/PlayerWindow.xaml.cs
@@ -38,8 +38,8 @@ public sealed partial class PlayerWindow : WindowBase
         InitializeComponent();
         Activated += OnActivated;
         Closed += OnClosed;
-        Width = 1280;
-        Height = 720;
+        Width = SettingsToolkit.ReadLocalSetting(SettingNames.PlayerWindowWidth, 1280d);
+        Height = SettingsToolkit.ReadLocalSetting(SettingNames.PlayerWindowHeight, 720d);
         MinWidth = 560;
         MinHeight = 320;
         AppWindow.Changed += OnAppWindowChanged;
@@ -95,6 +95,13 @@ public sealed partial class PlayerWindow : WindowBase
 
     private void OnClosed(object sender, WindowEventArgs args)
     {
+        // 保存当前窗口大小.
+        if (AppWindow.Presenter.Kind == AppWindowPresenterKind.Overlapped)
+        {
+            SettingsToolkit.WriteLocalSetting(SettingNames.PlayerWindowWidth, Width);
+            SettingsToolkit.WriteLocalSetting(SettingNames.PlayerWindowHeight, Height);
+        }
+
         MainFrame.Navigate(typeof(Page));
         MainWindow.Instance.Activate();
         GC.Collect();

--- a/src/Models/Models.Constants/App/SettingNames.cs
+++ b/src/Models/Models.Constants/App/SettingNames.cs
@@ -104,4 +104,6 @@ public enum SettingNames
     WindowHeight,
     BBDownConfigPath,
     HomeCustomModuleType,
+    PlayerWindowWidth,
+    PlayerWindowHeight,
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #61 

支持记录上一次播放窗口关闭时的宽高，并在下一次打开时恢复

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

播放器窗口每次都会以1280*720的大小打开

## 新的行为是什么？

记录上一次窗口关闭时的宽高

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
