### PR TITLE
1. HexToColor 方法未正确处理 16 进制颜色编码，2. 收藏夹重复加载第一页

### DIFF
--- a/src/Libs/Libs.Toolkit/AppToolkit.cs
+++ b/src/Libs/Libs.Toolkit/AppToolkit.cs
@@ -93,7 +93,10 @@ public static class AppToolkit
             hexCode = hexCode[1..];
         }
 
-        hexCode = Convert.ToInt32(hexCode).ToString("X2");
+        if(int.TryParse(hexCode, out var intValue))
+        {
+            hexCode = intValue.ToString("X2");
+        }
 
         var color = default(Color);
         if (hexCode.Length == 4)

--- a/src/ViewModels/Views/VideoFavoriteDetailViewModel/VideoFavoriteDetailViewModel.cs
+++ b/src/ViewModels/Views/VideoFavoriteDetailViewModel/VideoFavoriteDetailViewModel.cs
@@ -71,6 +71,11 @@ public sealed partial class VideoFavoriteDetailViewModel : InformationFlowViewMo
         var data = await FavoriteProvider.Instance.GetVideoFavoriteFolderDetailAsync(CurrentFolder.Id);
         foreach (var item in data.VideoSet.Items)
         {
+            if (Items.Any(p => p.Data.Identifier.Id == item.Identifier.Id))
+            {
+                continue;
+            }
+
             var videoVM = new VideoItemViewModel(item, additionalAction: RemoveVideo, additionalData: CurrentFolder.Id)
             {
                 CanRemove = IsMine,


### PR DESCRIPTION
## Close #78 #80 

78. HexToColor 方法未正确处理发送弹幕时传入的 16 进制颜色编码

80. 有时会重复获取第一页的数据，且未做判断直接加入列表

## PR 类型

- Bug 修复

## 当前行为是什么？

78. 直接使用 Convert.ToInt32 转换字符串导致异常

80. 获取下一页数据后，在加入列表前判断是否已存在

## 新的行为是什么？

78. 使用 TryParse 转换并判断，转换失败默认为是 合法的 无需转换的 颜色编码

80. 未探究为何会重复获取第一页，仅做了 Any 判断

## PR 检查清单

- [X] 应用成功启动
- [X] **不**包含破坏式更新

## 备注

**由于不熟悉 PR 操作，所以在此条未通过的情况下又做了提交，不得不重新编辑此条信息，下不为例**