### PR TITLE
保存播放器位置信息

### DIFF
--- a/src/Models/Models.Constants/App/SettingNames.cs
+++ b/src/Models/Models.Constants/App/SettingNames.cs
@@ -106,4 +106,6 @@ public enum SettingNames
     HomeCustomModuleType,
     PlayerWindowWidth,
     PlayerWindowHeight,
+    PlayerWindowLeft,
+    PlayerWindowTop,
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #71 

保存播放器上一次关闭时的位置信息

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

播放器始终在屏幕中央显示

## 新的行为是什么？

记住上一次关闭窗口时的位置，下一次打开播放窗口时在相同位置启动

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] **不**包含破坏式更新
