### PR TITLE
收藏列表刷新时默认收藏夹重复的问题

### DIFF
--- a/src/ViewModels/Views/VideoFavoriteDetailViewModel/VideoFavoriteDetailViewModel.cs
+++ b/src/ViewModels/Views/VideoFavoriteDetailViewModel/VideoFavoriteDetailViewModel.cs
@@ -48,8 +48,8 @@ public sealed partial class VideoFavoriteDetailViewModel : InformationFlowViewMo
         {
             var folders = await FavoriteProvider.Instance.GetVideoFavoriteViewAsync(AuthorizeProvider.Instance.CurrentUserId);
             _view = folders;
-            Folders.Add(folders.DefaultFolder.Folder);
             var folderList = folders.Groups.SelectMany(p => p.FavoriteSet.Items).ToList();
+            folderList.Insert(0, folders.DefaultFolder.Folder);
             foreach (var folder in folderList)
             {
                 if (Folders.Any(p => p.Equals(folder)))


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #86 

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

加载收藏夹列表时，用户的默认收藏夹固定加入 Folders

## 新的行为是什么？

默认收藏夹改为加入 folderList 变量，再通过后续流程去重添加

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [X] 应用成功启动
- [X] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

**此问题好像是 GetDataAsync 和 SelectFolderAsync 两个方法间有循环调用，可能与收藏夹列表下拉框的选择后事件有关。**
**奈何本人初次接触基于 XAML 的项目，能力实在有限，只能用最笨的方法处理此问题。😂**
