### PR TITLE
收藏夹列表的标题中增加总数

### DIFF
--- a/src/App/Controls/Modules/VideoFavoriteModule.xaml
+++ b/src/App/Controls/Modules/VideoFavoriteModule.xaml
@@ -26,7 +26,21 @@
             SelectionChanged="OnFolderComboBoxSelectionChanged">
             <ComboBox.ItemTemplate>
                 <DataTemplate x:DataType="video:VideoFavoriteFolder">
-                    <TextBlock Text="{x:Bind TitleAndTotalCount}" />
+                    <Grid ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Center" Text="{x:Bind Title}" />
+                        <TextBlock
+                            Grid.Column="1"
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Style="{StaticResource CaptionTextBlockStyle}">
+                            <Run FontWeight="Bold" FontSize="16" Text="·"></Run>
+                            <Run Text="{x:Bind TotalCount}"></Run>
+                        </TextBlock>
+                    </Grid>
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>

--- a/src/App/Controls/Modules/VideoFavoriteModule.xaml
+++ b/src/App/Controls/Modules/VideoFavoriteModule.xaml
@@ -26,7 +26,7 @@
             SelectionChanged="OnFolderComboBoxSelectionChanged">
             <ComboBox.ItemTemplate>
                 <DataTemplate x:DataType="video:VideoFavoriteFolder">
-                    <TextBlock Text="{x:Bind Title}" />
+                    <TextBlock Text="{x:Bind TitleAndTotalCount}" />
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>

--- a/src/Models/Models.Data/Video/VideoFavoriteFolder.cs
+++ b/src/Models/Models.Data/Video/VideoFavoriteFolder.cs
@@ -65,6 +65,11 @@ public sealed class VideoFavoriteFolder
     /// </summary>
     public int TotalCount { get; }
 
+    /// <summary>
+    /// 收藏夹标题和内容总数.
+    /// </summary>
+    public string TitleAndTotalCount => $"{Title} ({TotalCount})";
+
     /// <inheritdoc/>
     public override bool Equals(object obj) => obj is VideoFavoriteFolder folder && Id == folder.Id;
 

--- a/src/Models/Models.Data/Video/VideoFavoriteFolder.cs
+++ b/src/Models/Models.Data/Video/VideoFavoriteFolder.cs
@@ -65,11 +65,6 @@ public sealed class VideoFavoriteFolder
     /// </summary>
     public int TotalCount { get; }
 
-    /// <summary>
-    /// 收藏夹标题和内容总数.
-    /// </summary>
-    public string TitleAndTotalCount => $"{Title} ({TotalCount})";
-
     /// <inheritdoc/>
     public override bool Equals(object obj) => obj is VideoFavoriteFolder folder && Id == folder.Id;
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

收藏夹列表只有标题

## 新的行为是什么？

收藏夹列表标题后增加视频数量

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [X] 应用成功启动
- [X] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
