### PR TITLE
添加播放器类型数据采集

### DIFF
--- a/src/App/Controls/Modules/VideoFavoriteModule.xaml
+++ b/src/App/Controls/Modules/VideoFavoriteModule.xaml
@@ -26,21 +26,20 @@
             SelectionChanged="OnFolderComboBoxSelectionChanged">
             <ComboBox.ItemTemplate>
                 <DataTemplate x:DataType="video:VideoFavoriteFolder">
-                    <Grid ColumnSpacing="8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock VerticalAlignment="Center" Text="{x:Bind Title}" />
+                    <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock
-                            Grid.Column="1"
+                            MaxWidth="300"
+                            VerticalAlignment="Center"
+                            Text="{x:Bind Title}"
+                            TextTrimming="CharacterEllipsis" />
+                        <TextBlock
                             VerticalAlignment="Center"
                             Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                             Style="{StaticResource CaptionTextBlockStyle}">
-                            <Run FontWeight="Bold" FontSize="16" Text="·"></Run>
-                            <Run Text="{x:Bind TotalCount}"></Run>
+                            <Run FontWeight="Bold" Text="· " />
+                            <Run Text="{x:Bind TotalCount}" />
                         </TextBlock>
-                    </Grid>
+                    </StackPanel>
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>

--- a/src/App/Forms/PlayerWindow.xaml.cs
+++ b/src/App/Forms/PlayerWindow.xaml.cs
@@ -72,7 +72,8 @@ public sealed partial class PlayerWindow : WindowBase
             snapshot.VideoType.ToString(),
             SettingsToolkit.ReadLocalSetting(SettingNames.PreferCodec, PreferCodec.H264).ToString(),
             SettingsToolkit.ReadLocalSetting(SettingNames.PreferQuality, PreferQuality.HDFirst).ToString(),
-            SettingsToolkit.ReadLocalSetting(SettingNames.DecodeType, DecodeType.HardwareDecode).ToString());
+            SettingsToolkit.ReadLocalSetting(SettingNames.DecodeType, DecodeType.HardwareDecode).ToString(),
+            SettingsToolkit.ReadLocalSetting(SettingNames.PlayerType, PlayerType.Native).ToString());
     }
 
     /// <summary>

--- a/src/App/TraceLogger.cs
+++ b/src/App/TraceLogger.cs
@@ -84,7 +84,8 @@ internal sealed class TraceLogger
         string videoType,
         string preferCodec,
         string preferQuality,
-        string decodeType)
+        string decodeType,
+        string playerType)
     {
         var data = new Dictionary<string, string>
         {
@@ -92,6 +93,7 @@ internal sealed class TraceLogger
             { "PreferCodec", preferCodec },
             { "PreferQuality", preferQuality },
             { "DecodeType", decodeType },
+            { "PlayerType", playerType },
         };
 
         Analytics.TrackEvent(PlayerOpenEvent, data);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

采集播放器类型数据，以此判断用户对 Native 和 ffmpeg 的倾向

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
- 重构 （没有功能修改，没有 API 更新）
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

没有采集播放器类型数据

## 新的行为是什么？

采集播放器类型数据

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

顺便修改了一下收藏夹选择项的UI，使视频数居中显示
