### PR TITLE
修复跳转视频提示不正常弹出的问题

### DIFF
--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
@@ -254,7 +254,7 @@ public sealed partial class PlayerDetailViewModel
     {
         _ = _dispatcherQueue.TryEnqueue(() =>
         {
-            IsError = e.Status == PlayerStatus.Failed || !string.IsNullOrEmpty(Player.LastError);
+            IsError = e.Status == PlayerStatus.Failed || !string.IsNullOrEmpty(Player?.LastError);
             Status = e.Status;
             IsMediaPause = e.Status != PlayerStatus.Playing;
             IsBuffering = e.Status == PlayerStatus.Buffering;

--- a/src/ViewModels/Views/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Methods.cs
+++ b/src/ViewModels/Views/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Methods.cs
@@ -134,6 +134,12 @@ public sealed partial class PgcPlayerPageViewModel
     {
         if (_playNextEpisodeAction == null)
         {
+            var isAutoCloseWindowWhenEnded = SettingsToolkit.ReadLocalSetting(SettingNames.IsAutoCloseWindowWhenEnded, false);
+            if (isAutoCloseWindowWhenEnded)
+            {
+                PlayerDetail.ShowAutoCloseWindowTipCommand.Execute(default);
+            }
+
             return;
         }
 

--- a/src/ViewModels/Views/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
+++ b/src/ViewModels/Views/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
@@ -207,18 +207,19 @@ public sealed partial class VideoPlayerPageViewModel
             if (isContinue)
             {
                 _playNextVideoAction?.Invoke();
-                return;
             }
+            else
+            {
+                PlayerDetail.ShowNextVideoTipCommand.Execute(default);
+            }
+
+            return;
         }
 
         var isAutoCloseWindowWhenEnded = SettingsToolkit.ReadLocalSetting(SettingNames.IsAutoCloseWindowWhenEnded, false);
         if (isAutoCloseWindowWhenEnded)
         {
             PlayerDetail.ShowAutoCloseWindowTipCommand.Execute(default);
-        }
-        else
-        {
-            PlayerDetail.ShowNextVideoTipCommand.Execute(default);
         }
     }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #110 

修复当视频播放结束后，会在不启用连续播放的情况下弹出播放下一视频的提示

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

视频播放结束后，即便没有下一个要播放的视频也会弹出提示

## 新的行为是什么？

修复这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
