### PR TITLE
修复标题栏返回按钮交互区域受限的问题

### DIFF
--- a/src/App/Controls/AppTitleBar.xaml.cs
+++ b/src/App/Controls/AppTitleBar.xaml.cs
@@ -111,12 +111,12 @@ public sealed partial class AppTitleBar : UserControl
         var windowHandle = WindowNative.GetWindowHandle(AttachedWindow);
         var scaleFactor = Windows.Win32.PInvoke.GetDpiForWindow(new Windows.Win32.Foundation.HWND(windowHandle)) / 96d;
         var leftInset = AttachedWindow.AppWindow.TitleBar.LeftInset;
-        var leftPadding = BackButtonVisibility == Visibility.Visible ? 48 * scaleFactor : 0;
+        var leftPadding = BackButtonVisibility == Visibility.Visible ? BackButton.ActualWidth : 0;
         var dragRect = default(RectInt32);
-        dragRect.X = Convert.ToInt32(leftInset + leftPadding);
+        dragRect.X = Convert.ToInt32((leftInset + leftPadding + 4) * scaleFactor);
         dragRect.Y = 0;
         dragRect.Height = Convert.ToInt32(ActualHeight * scaleFactor);
-        dragRect.Width = Convert.ToInt32((ActualWidth * scaleFactor) - leftPadding);
+        dragRect.Width = Convert.ToInt32((ActualWidth * scaleFactor) - dragRect.X);
         AttachedWindow.AppWindow.TitleBar.SetDragRectangles(new[] { dragRect });
     }
 

--- a/src/App/Forms/MainWindow.xaml.cs
+++ b/src/App/Forms/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ public sealed partial class MainWindow : WindowBase
     {
         InitializeComponent();
         Instance = this;
+        SetTitleBar(CustomTitleBar);
         CustomTitleBar.AttachedWindow = this;
         IsMaximizable = false;
         _appViewModel.NavigateRequest += OnAppViewModelNavigateRequest;

--- a/src/App/Forms/WindowBase.cs
+++ b/src/App/Forms/WindowBase.cs
@@ -20,6 +20,7 @@ public class WindowBase : WindowEx
         AppWindow.TitleBar.ExtendsContentIntoTitleBar = true;
         AppWindow.TitleBar.ButtonBackgroundColor = Colors.Transparent;
         AppWindow.TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
+        AppWindow.TitleBar.IconShowOptions = Microsoft.UI.Windowing.IconShowOptions.HideIconAndSystemMenu;
         SystemBackdrop = new Microsoft.UI.Xaml.Media.MicaBackdrop();
         Title = ResourceToolkit.GetLocalizedString(StringNames.AppName);
         this.SetIcon("Assets/logo.ico");


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #111 #73

修复标题栏返回按钮的交互区域总是少一块的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

当尝试点击返回按钮时，总是在左侧中间区域有一部分不可交互，很容易误触发系统菜单

## 新的行为是什么？

禁用了默认的系统菜单选项，修复了这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
