### PR TITLE
修复去除 P2P CDN 没有生效的问题

### DIFF
--- a/src/Libs/Libs.Adapter/LiveAdapter.cs
+++ b/src/Libs/Libs.Adapter/LiveAdapter.cs
@@ -178,7 +178,7 @@ public static class LiveAdapter
                 foreach (var codec in format.CodecList)
                 {
                     var name = codec.CodecName;
-                    var urls = codec.Urls.Select(p => new LivePlayUrl(stream.ProtocolName, p.Host, codec.BaseUrl, p.Extra));
+                    var urls = codec.Urls.Select(p => new LivePlayUrl(stream.ProtocolName, p.Host, codec.BaseUrl, p.Extra)).ToList();
                     lines.Add(new LivePlaylineInformation(name, codec.CurrentQuality, codec.AcceptQualities, urls));
                 }
             }

--- a/src/Libs/Libs.Adapter/PlayerAdapter.cs
+++ b/src/Libs/Libs.Adapter/PlayerAdapter.cs
@@ -61,10 +61,10 @@ public static class PlayerAdapter
 
         var minBuffer = dash.MinBufferTime;
         var videos = dash.Video?.Count > 0
-            ? dash.Video.Select(ConvertToSegmentInformation)
+            ? dash.Video.Select(ConvertToSegmentInformation).ToList()
             : null;
         var audios = dash.Audio?.Count > 0
-            ? dash.Audio.Select(ConvertToSegmentInformation)
+            ? dash.Audio.Select(ConvertToSegmentInformation).ToList()
             : null;
         var formats = information.SupportFormats.Select(ConvertToFormatInformation).ToList();
         return new MediaInformation(minBuffer, videos, audios, formats);

--- a/src/Models/Models.Data/Live/LiveMediaInformation.cs
+++ b/src/Models/Models.Data/Live/LiveMediaInformation.cs
@@ -17,8 +17,8 @@ public sealed class LiveMediaInformation
     /// <param name="lines">直播线路.</param>
     public LiveMediaInformation(
         string id,
-        IEnumerable<FormatInformation> formats,
-        IEnumerable<LivePlaylineInformation> lines)
+        List<FormatInformation> formats,
+        List<LivePlaylineInformation> lines)
     {
         Id = id;
         Formats = formats;
@@ -33,10 +33,10 @@ public sealed class LiveMediaInformation
     /// <summary>
     /// 格式列表.
     /// </summary>
-    public IEnumerable<FormatInformation> Formats { get; }
+    public List<FormatInformation> Formats { get; }
 
     /// <summary>
     /// 播放线路列表.
     /// </summary>
-    public IEnumerable<LivePlaylineInformation> Lines { get; }
+    public List<LivePlaylineInformation> Lines { get; }
 }

--- a/src/Models/Models.Data/Live/LivePlaylineInformation.cs
+++ b/src/Models/Models.Data/Live/LivePlaylineInformation.cs
@@ -17,8 +17,8 @@ public sealed class LivePlaylineInformation
     public LivePlaylineInformation(
         string name,
         int quality,
-        IEnumerable<int> acceptQualities,
-        IEnumerable<LivePlayUrl> urls)
+        List<int> acceptQualities,
+        List<LivePlayUrl> urls)
     {
         Name = name;
         Quality = quality;
@@ -39,10 +39,10 @@ public sealed class LivePlaylineInformation
     /// <summary>
     /// 支持的清晰度标识.
     /// </summary>
-    public IEnumerable<int> AcceptQualities { get; }
+    public List<int> AcceptQualities { get; }
 
     /// <summary>
     /// 播放地址列表.
     /// </summary>
-    public IEnumerable<LivePlayUrl> Urls { get; }
+    public List<LivePlayUrl> Urls { get; }
 }

--- a/src/Models/Models.Data/Player/MediaInformation.cs
+++ b/src/Models/Models.Data/Player/MediaInformation.cs
@@ -16,9 +16,9 @@ public sealed class MediaInformation
     /// <param name="formats">格式列表.</param>
     public MediaInformation(
         double minBufferTime,
-        IEnumerable<SegmentInformation> videoSegments,
-        IEnumerable<SegmentInformation> audioSegments,
-        IEnumerable<FormatInformation> formats)
+        List<SegmentInformation> videoSegments,
+        List<SegmentInformation> audioSegments,
+        List<FormatInformation> formats)
     {
         MinBufferTime = minBufferTime;
         VideoSegments = videoSegments;
@@ -34,15 +34,15 @@ public sealed class MediaInformation
     /// <summary>
     /// 不同清晰度的视频列表.
     /// </summary>
-    public IEnumerable<SegmentInformation> VideoSegments { get; }
+    public List<SegmentInformation> VideoSegments { get; }
 
     /// <summary>
     /// 不同码率的音频列表.
     /// </summary>
-    public IEnumerable<SegmentInformation> AudioSegments { get; }
+    public List<SegmentInformation> AudioSegments { get; }
 
     /// <summary>
     /// 格式列表.
     /// </summary>
-    public IEnumerable<FormatInformation> Formats { get; }
+    public List<FormatInformation> Formats { get; }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #133 

当开启选项时，将所有 P2P CDN 的链接都替换成普通 CDN

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

开启 P2P CDN 屏蔽后，没有匹配到正确的 P2P CDN 链接

## 新的行为是什么？

修复这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
