### PR TITLE
支持单一播放器窗口

### DIFF
--- a/src/App/Controls/Settings/PlayerModeSettingSection.xaml
+++ b/src/App/Controls/Settings/PlayerModeSettingSection.xaml
@@ -37,6 +37,15 @@
                     </ComboBox.ItemTemplate>
                 </ComboBox>
             </labs:SettingsCard>
+            <labs:SettingsCard Header="{ext:Locale Name=PlayerWindowBehavior}">
+                <ComboBox
+                    x:Name="PlayerWindowBehaviorComboBox"
+                    MinWidth="120"
+                    SelectionChanged="OnPlayerWindowBehaviorComboBoxSelectionChanged">
+                    <ComboBoxItem Content="{ext:Locale Name=SingleWindow}" />
+                    <ComboBoxItem Content="{ext:Locale Name=MultipleWindow}" />
+                </ComboBox>
+            </labs:SettingsCard>
             <labs:SettingsCard Header="{ext:Locale Name=PreferQuality}">
                 <ComboBox
                     MinWidth="120"

--- a/src/App/Controls/Settings/PlayerModeSettingSection.xaml.cs
+++ b/src/App/Controls/Settings/PlayerModeSettingSection.xaml.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using Bili.Copilot.Models.Constants.Player;
+using Microsoft.UI.Xaml;
+
 namespace Bili.Copilot.App.Controls.Settings;
 
 /// <summary>
@@ -10,5 +13,25 @@ public sealed partial class PlayerModeSettingSection : SettingSection
     /// <summary>
     /// Initializes a new instance of the <see cref="PlayerModeSettingSection"/> class.
     /// </summary>
-    public PlayerModeSettingSection() => InitializeComponent();
+    public PlayerModeSettingSection()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        var playerWindowSelectIndex = (int)ViewModel.PlayerWindowBehavior;
+        PlayerWindowBehaviorComboBox.SelectedIndex = playerWindowSelectIndex;
+    }
+
+    private void OnPlayerWindowBehaviorComboBoxSelectionChanged(object sender, Microsoft.UI.Xaml.Controls.SelectionChangedEventArgs e)
+    {
+        if(!IsLoaded)
+        {
+            return;
+        }
+
+        ViewModel.PlayerWindowBehavior = (PlayerWindowBehavior)PlayerWindowBehaviorComboBox.SelectedIndex;
+    }
 }

--- a/src/App/Forms/PlayerWindow.xaml.cs
+++ b/src/App/Forms/PlayerWindow.xaml.cs
@@ -11,6 +11,7 @@ using Bili.Copilot.Models.Constants.App;
 using Bili.Copilot.Models.Constants.Player;
 using Bili.Copilot.Models.Data.Local;
 using Bili.Copilot.Models.Data.Video;
+using Bili.Copilot.ViewModels;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -41,6 +42,13 @@ public sealed partial class PlayerWindow : WindowBase
         MinWidth = 560;
         MinHeight = 320;
         AppWindow.Changed += OnAppWindowChanged;
+
+        var behavior = SettingsToolkit.ReadLocalSetting(SettingNames.PlayerWindowBehavior, PlayerWindowBehavior.Multiple);
+        if (behavior == PlayerWindowBehavior.Single)
+        {
+            AppViewModel.Instance.LastPlayerWindow?.Close();
+            AppViewModel.Instance.LastPlayerWindow = this;
+        }
     }
 
     /// <summary>
@@ -105,6 +113,7 @@ public sealed partial class PlayerWindow : WindowBase
             SettingsToolkit.WriteLocalSetting(SettingNames.PlayerWindowTop, top);
         }
 
+        AppViewModel.Instance.LastPlayerWindow = null;
         MainFrame.Navigate(typeof(Page));
         MainWindow.Instance.Activate();
         GC.Collect();

--- a/src/App/Resources/zh-Hans/Resources.resw
+++ b/src/App/Resources/zh-Hans/Resources.resw
@@ -2049,4 +2049,13 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   <data name="AutoClosePlayerWindowDescription" xml:space="preserve">
     <value>当前播放窗口即将关闭，您可以关闭此提示以保留窗口</value>
   </data>
+  <data name="MultipleWindow" xml:space="preserve">
+    <value>多窗口</value>
+  </data>
+  <data name="PlayerWindowBehavior" xml:space="preserve">
+    <value>播放器窗口新建行为</value>
+  </data>
+  <data name="SingleWindow" xml:space="preserve">
+    <value>单窗口</value>
+  </data>
 </root>

--- a/src/App/Resources/zh-Hant/Resources.resw
+++ b/src/App/Resources/zh-Hant/Resources.resw
@@ -2046,4 +2046,13 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集視頻 &gt; 關聯視頻 (如�
   <data name="AutoClosePlayerWindowDescription" xml:space="preserve">
     <value>當前播放視窗即將關閉，您可以關閉此提示以保留視窗</value>
   </data>
+  <data name="MultipleWindow" xml:space="preserve">
+    <value>多視窗</value>
+  </data>
+  <data name="PlayerWindowBehavior" xml:space="preserve">
+    <value>播放器視窗新建行為</value>
+  </data>
+  <data name="SingleWindow" xml:space="preserve">
+    <value>單視窗</value>
+  </data>
 </root>

--- a/src/Models/Models.Constants/App/SettingNames.cs
+++ b/src/Models/Models.Constants/App/SettingNames.cs
@@ -111,4 +111,5 @@ public enum SettingNames
     IsAutoCloseWindowWhenEnded,
     SettingsTipVersion,
     WindowWidth,
+    PlayerWindowBehavior,
 }

--- a/src/Models/Models.Constants/Player/PlayerWindowBehavior.cs
+++ b/src/Models/Models.Constants/Player/PlayerWindowBehavior.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Bili Copilot. All rights reserved.
+
+namespace Bili.Copilot.Models.Constants.Player;
+
+/// <summary>
+/// 播放器窗口行为.
+/// </summary>
+public enum PlayerWindowBehavior
+{
+    /// <summary>
+    /// 单窗口.
+    /// </summary>
+    Single,
+
+    /// <summary>
+    /// 多窗口.
+    /// </summary>
+    Multiple,
+}

--- a/src/ViewModels/Components/AppViewModel/AppViewModel.Properties.cs
+++ b/src/ViewModels/Components/AppViewModel/AppViewModel.Properties.cs
@@ -12,6 +12,7 @@ using Bili.Copilot.Models.Data.Video;
 using Bili.Copilot.ViewModels.Items;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 
 namespace Bili.Copilot.ViewModels;
 
@@ -141,4 +142,9 @@ public sealed partial class AppViewModel
     /// 导航条目列表.
     /// </summary>
     public ObservableCollection<NavigateItemViewModel> NavigateItems { get; }
+
+    /// <summary>
+    /// 上次打开的播放器窗口.
+    /// </summary>
+    public Window LastPlayerWindow { get; set; }
 }

--- a/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
+++ b/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
@@ -99,6 +99,9 @@ public sealed partial class SettingsPageViewModel
     [ObservableProperty]
     private bool _hideWhenCloseWindow;
 
+    [ObservableProperty]
+    private PlayerWindowBehavior _playerWindowBehavior;
+
     /// <summary>
     /// 实例.
     /// </summary>

--- a/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.cs
+++ b/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.cs
@@ -50,6 +50,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
         GlobalPlaybackRate = ReadSetting(SettingNames.GlobalPlaybackRate, false);
         IsFullTraditionalChinese = ReadSetting(SettingNames.IsFullTraditionalChinese, false);
         HideWhenCloseWindow = ReadSetting(SettingNames.HideWhenCloseWindow, false);
+        PlayerWindowBehavior = ReadSetting(SettingNames.PlayerWindowBehavior, PlayerWindowBehavior.Multiple);
         PreferCodecInit();
         DecodeInit();
         PlayerModeInit();
@@ -152,6 +153,9 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
                 break;
             case nameof(PlayerType):
                 WriteSetting(SettingNames.PlayerType, PlayerType);
+                break;
+            case nameof(PlayerWindowBehavior):
+                WriteSetting(SettingNames.PlayerWindowBehavior, PlayerWindowBehavior);
                 break;
             default:
                 break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #106 

添加新的设置项，以允许用户调整是否每次点击新的视频都会打开新的播放窗口。

路径是 `设置` -> `播放模式` -> `播放器窗口新建行为`

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

每次打开新的视频都会创建一个新的播放窗口

## 新的行为是什么？

在设置中添加设置项，当调整为 `单窗口` 时，会在打开新窗口前关闭之前的播放窗口

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
