### PR TITLE
支持一键复制视频播放地址

### DIFF
--- a/src/App/Controls/Base/VideoItem/VideoItem.xaml
+++ b/src/App/Controls/Base/VideoItem/VideoItem.xaml
@@ -44,6 +44,11 @@
                                             <local:FluentIcon Symbol="Globe" />
                                         </MenuFlyoutItem.Icon>
                                     </MenuFlyoutItem>
+                                    <MenuFlyoutItem Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.CopyUrlCommand}" Text="{ext:Locale Name=CopyVideoUrl}">
+                                        <MenuFlyoutItem.Icon>
+                                            <local:FluentIcon Symbol="Copy" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
                                     <MenuFlyoutItem Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.FixCommand}" Text="{ext:Locale Name=FixContent}">
                                         <MenuFlyoutItem.Icon>
                                             <local:FluentIcon Symbol="Pin" />
@@ -227,6 +232,11 @@
                                             <local:FluentIcon Symbol="Globe" />
                                         </MenuFlyoutItem.Icon>
                                     </MenuFlyoutItem>
+                                    <MenuFlyoutItem Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.CopyUrlCommand}" Text="{ext:Locale Name=CopyVideoUrl}">
+                                        <MenuFlyoutItem.Icon>
+                                            <local:FluentIcon Symbol="Copy" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
                                     <MenuFlyoutItem Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.FixCommand}" Text="{ext:Locale Name=FixContent}">
                                         <MenuFlyoutItem.Icon>
                                             <local:FluentIcon Symbol="Pin" />
@@ -393,6 +403,11 @@
                                 <MenuFlyoutItem Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.OpenInBrowserCommand}" Text="{ext:Locale Name=OpenInBrowser}">
                                     <MenuFlyoutItem.Icon>
                                         <local:FluentIcon Symbol="Globe" />
+                                    </MenuFlyoutItem.Icon>
+                                </MenuFlyoutItem>
+                                <MenuFlyoutItem Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.CopyUrlCommand}" Text="{ext:Locale Name=CopyVideoUrl}">
+                                    <MenuFlyoutItem.Icon>
+                                        <local:FluentIcon Symbol="Copy" />
                                     </MenuFlyoutItem.Icon>
                                 </MenuFlyoutItem>
                                 <MenuFlyoutItem Command="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.FixCommand}" Text="{ext:Locale Name=FixContent}">

--- a/src/App/Controls/Modules/HistoryModule.xaml
+++ b/src/App/Controls/Modules/HistoryModule.xaml
@@ -18,6 +18,16 @@
             <base:VideoItem ViewModel="{x:Bind}">
                 <base:VideoItem.ContextFlyout>
                     <MenuFlyout>
+                        <MenuFlyoutItem Command="{x:Bind OpenInBrowserCommand}" Text="{ext:Locale Name=OpenInBrowser}">
+                            <MenuFlyoutItem.Icon>
+                                <base:FluentIcon Symbol="Globe" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Command="{x:Bind CopyUrlCommand}" Text="{ext:Locale Name=CopyVideoUrl}">
+                            <MenuFlyoutItem.Icon>
+                                <base:FluentIcon Symbol="Copy" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
                         <MenuFlyoutItem
                             MinWidth="160"
                             Command="{x:Bind RemoveFromHistoryCommand}"

--- a/src/App/Controls/Modules/VideoFavoriteModule.xaml
+++ b/src/App/Controls/Modules/VideoFavoriteModule.xaml
@@ -19,6 +19,16 @@
             <base:VideoItem ViewModel="{x:Bind}">
                 <base:VideoItem.ContextFlyout>
                     <MenuFlyout>
+                        <MenuFlyoutItem Command="{x:Bind OpenInBrowserCommand}" Text="{ext:Locale Name=OpenInBrowser}">
+                            <MenuFlyoutItem.Icon>
+                                <base:FluentIcon Symbol="Globe" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Command="{x:Bind CopyUrlCommand}" Text="{ext:Locale Name=CopyVideoUrl}">
+                            <MenuFlyoutItem.Icon>
+                                <base:FluentIcon Symbol="Copy" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
                         <MenuFlyoutItem
                             MinWidth="160"
                             Command="{x:Bind RemoveFromFavoriteCommand}"

--- a/src/App/Controls/Modules/VideoInformationView.xaml
+++ b/src/App/Controls/Modules/VideoInformationView.xaml
@@ -356,6 +356,11 @@
             </labs:SettingsCard>
 
             <base:DownloadSection Margin="0,-4,0,0" ViewModel="{x:Bind ViewModel.PlayerDetail.DownloadViewModel, Mode=OneWay}" />
+            <HyperlinkButton
+                HorizontalAlignment="Left"
+                Click="OnCopyVideoUrlButtonClick"
+                Content="{ext:Locale Name=CopyVideoUrl}"
+                FontSize="12" />
 
             <!--  视频参数  -->
             <base:MediaStatsPanel

--- a/src/App/Controls/Modules/VideoInformationView.xaml.cs
+++ b/src/App/Controls/Modules/VideoInformationView.xaml.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
 using Bili.Copilot.App.Controls.Base;
+using Bili.Copilot.Libs.Toolkit;
+using Bili.Copilot.Models.Constants.App;
 using Bili.Copilot.Models.Data.Community;
 using Bili.Copilot.ViewModels;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace Bili.Copilot.App.Controls.Modules;
 
@@ -88,6 +91,15 @@ public sealed partial class VideoInformationView : VideoInformationViewBase
         {
             ViewModel.PlayerDetail.ChangeAudioOnlyCommand.Execute(isAudioOnly);
         }
+    }
+
+    private void OnCopyVideoUrlButtonClick(object sender, RoutedEventArgs e)
+    {
+        var url = $"https://www.bilibili.com/video/av{ViewModel.View.Information.Identifier.Id}";
+        var dp = new DataPackage();
+        dp.SetText(url);
+        Clipboard.SetContent(dp);
+        AppViewModel.Instance.ShowTip(ResourceToolkit.GetLocalizedString(StringNames.Copied), InfoType.Success);
     }
 }
 

--- a/src/App/Controls/Modules/ViewLaterModule.xaml
+++ b/src/App/Controls/Modules/ViewLaterModule.xaml
@@ -18,6 +18,16 @@
             <base:VideoItem ViewModel="{x:Bind}">
                 <base:VideoItem.ContextFlyout>
                     <MenuFlyout>
+                        <MenuFlyoutItem Command="{x:Bind OpenInBrowserCommand}" Text="{ext:Locale Name=OpenInBrowser}">
+                            <MenuFlyoutItem.Icon>
+                                <base:FluentIcon Symbol="Globe" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Command="{x:Bind CopyUrlCommand}" Text="{ext:Locale Name=CopyVideoUrl}">
+                            <MenuFlyoutItem.Icon>
+                                <base:FluentIcon Symbol="Copy" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
                         <MenuFlyoutItem
                             MinWidth="160"
                             Command="{x:Bind RemoveFromViewLaterCommand}"

--- a/src/App/Resources/zh-Hans/Resources.resw
+++ b/src/App/Resources/zh-Hans/Resources.resw
@@ -2106,4 +2106,7 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   <data name="SystemDefault" xml:space="preserve">
     <value>使用系统设置</value>
   </data>
+  <data name="CopyVideoUrl" xml:space="preserve">
+    <value>复制视频网址</value>
+  </data>
 </root>

--- a/src/App/Resources/zh-Hant/Resources.resw
+++ b/src/App/Resources/zh-Hant/Resources.resw
@@ -2103,4 +2103,7 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集視頻 &gt; 關聯視頻 (如�
   <data name="SystemDefault" xml:space="preserve">
     <value>使用系統設置</value>
   </data>
+  <data name="CopyVideoUrl" xml:space="preserve">
+    <value>複製視訊網址</value>
+  </data>
 </root>

--- a/src/ViewModels/Items/VideoItemViewModel/VideoItemViewModel.cs
+++ b/src/ViewModels/Items/VideoItemViewModel/VideoItemViewModel.cs
@@ -9,6 +9,7 @@ using Bili.Copilot.Models.Constants.Authorize;
 using Bili.Copilot.Models.Data.Local;
 using Bili.Copilot.Models.Data.Video;
 using CommunityToolkit.Mvvm.Input;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 
 namespace Bili.Copilot.ViewModels;
@@ -180,6 +181,16 @@ public sealed partial class VideoItemViewModel : ViewModelBase
             Data.Identifier.Title,
             Data.Identifier.Id,
             FixedType.Video));
+    }
+
+    [RelayCommand]
+    private void CopyUrl()
+    {
+        var url = $"https://www.bilibili.com/video/av{Data.Identifier.Id}";
+        var dp = new DataPackage();
+        dp.SetText(url);
+        Clipboard.SetContent(dp);
+        AppViewModel.Instance.ShowTip(ResourceToolkit.GetLocalizedString(StringNames.Copied), InfoType.Success);
     }
 
     private void InitializeData()

--- a/src/ViewModels/Views/VideoFavoriteDetailViewModel/VideoFavoriteDetailViewModel.cs
+++ b/src/ViewModels/Views/VideoFavoriteDetailViewModel/VideoFavoriteDetailViewModel.cs
@@ -74,14 +74,14 @@ public sealed partial class VideoFavoriteDetailViewModel : InformationFlowViewMo
             }
         }
 
-        IsEmpty = CurrentFolder.Data.TotalCount == 0;
-        if (IsEmpty)
-        {
-            return;
-        }
-
         if (CurrentFolder != null)
         {
+            IsEmpty = CurrentFolder.Data.TotalCount == 0;
+            if (IsEmpty)
+            {
+                return;
+            }
+
             var data = await FavoriteProvider.Instance.GetVideoFavoriteFolderDetailAsync(CurrentFolder.Data.Id);
             foreach (var item in data.VideoSet.Items)
             {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #171

支持在视频条目右键菜单和视频播放信息中复制视频的播放网址

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

不支持复制视频网址

## 新的行为是什么？

支持

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
