### PR TITLE
修复影视索引排序问题

### DIFF
--- a/src/App/Controls/Modules/FilmNavListModule.xaml
+++ b/src/App/Controls/Modules/FilmNavListModule.xaml
@@ -138,7 +138,7 @@
             <base:LoadingOverlapper IsOpen="{x:Bind _tvRecommendDetailViewModel.IsReloading, Mode=OneWay}" Text="{ext:Locale Name=LoadingAndWait}" />
         </Grid>
 
-        <!--  电视剧索引  -->
+        <!--  纪录片索引  -->
         <Grid Grid.Row="1" Visibility="{x:Bind ViewModel.IsDocumentaryShown, Mode=OneWay}">
             <ScrollViewer Padding="12,0" Style="{StaticResource PageScrollViewerStyle}">
                 <ItemsRepeater Margin="0,0,0,12" ItemsSource="{x:Bind _documentaryRecommendDetailViewModel.Filters}">

--- a/src/App/Controls/Modules/LivePartitionDetailModule.xaml.cs
+++ b/src/App/Controls/Modules/LivePartitionDetailModule.xaml.cs
@@ -23,18 +23,20 @@ public sealed partial class LivePartitionDetailModule : LivePartitionDetailModul
     }
 
     private void OnUnloaded(object sender, RoutedEventArgs e)
-        => ViewModel.RequestScrollToTop -= OnRequestScrollToTop;
+        => ViewModel.RequestScrollToTop -= OnRequestScrollToTopAsync;
 
     private void OnLoaded(object sender, RoutedEventArgs e)
-        => ViewModel.RequestScrollToTop += OnRequestScrollToTop;
+        => ViewModel.RequestScrollToTop += OnRequestScrollToTopAsync;
 
-    private void OnRequestScrollToTop(object sender, EventArgs e)
-        => ContentScrollViewer.ChangeView(default, 0, default, true);
+    private async void OnRequestScrollToTopAsync(object sender, EventArgs e)
+    {
+        await Task.Delay(200);
+        ContentScrollViewer.ChangeView(default, 0, default);
+    }
 
     private void OnDetailNavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
     {
         var data = args.InvokedItem as LiveTag;
-        _ = ContentScrollViewer.ChangeView(default, 0, default, true);
         ViewModel.SelectTagCommand.Execute(data);
     }
 

--- a/src/App/Controls/Modules/PgcRecommendModule.xaml.cs
+++ b/src/App/Controls/Modules/PgcRecommendModule.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class PgcRecommendModule : PgcRecommendModuleBase
     {
         InitializeComponent();
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
     }
 
     /// <summary>
@@ -46,6 +47,24 @@ public sealed partial class PgcRecommendModule : PgcRecommendModuleBase
             PgcType.Documentary => DocumentaryRecommendDetailViewModel.Instance,
             _ => throw new ArgumentOutOfRangeException(nameof(PgcType))
         };
+
+        ViewModel.RequestScrollToTop += OnRequestScrollToTopAsync;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel == null)
+        {
+            return;
+        }
+
+        ViewModel.RequestScrollToTop -= OnRequestScrollToTopAsync;
+    }
+
+    private async void OnRequestScrollToTopAsync(object sender, EventArgs e)
+    {
+        await Task.Delay(200);
+        ContentScrollViewer.ChangeView(0, 0, default);
     }
 
     private void OnSeasonViewIncrementalTriggered(object sender, EventArgs e)

--- a/src/ViewModels/Views/LivePartitionDetailViewModel/LivePartitionDetailViewModel.cs
+++ b/src/ViewModels/Views/LivePartitionDetailViewModel/LivePartitionDetailViewModel.cs
@@ -61,6 +61,8 @@ public sealed partial class LivePartitionDetailViewModel : InformationFlowViewMo
 
         _totalCount = data.TotalCount;
 
+        var canScrollToTop = Items.Count == 0;
+
         if (data.Lives?.Count() > 0)
         {
             foreach (var live in data.Lives)
@@ -83,6 +85,10 @@ public sealed partial class LivePartitionDetailViewModel : InformationFlowViewMo
         }
 
         IsEmpty = Items.Count == 0;
+        if (canScrollToTop && !IsEmpty)
+        {
+            RequestScrollToTop?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     [RelayCommand]
@@ -113,14 +119,12 @@ public sealed partial class LivePartitionDetailViewModel : InformationFlowViewMo
                 var liveVM = new LiveItemViewModel(live);
                 Items.Add(liveVM);
             }
+
+            RequestScrollToTop?.Invoke(this, EventArgs.Empty);
         }
         else
         {
             _ = ReloadCommand.ExecuteAsync(null);
         }
     }
-
-    [RelayCommand]
-    private void ScrollToTop()
-        => RequestScrollToTop?.Invoke(this, EventArgs.Empty);
 }

--- a/src/ViewModels/Views/PgcRecommendDetailViewModel/PgcRecommendDetailViewModel.Properties.cs
+++ b/src/ViewModels/Views/PgcRecommendDetailViewModel/PgcRecommendDetailViewModel.Properties.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using System;
 using System.Collections.ObjectModel;
 using Bili.Copilot.Models.Constants.Bili;
 using Bili.Copilot.ViewModels.Items;
@@ -20,6 +21,11 @@ public partial class PgcRecommendDetailViewModel
 
     [ObservableProperty]
     private string _title;
+
+    /// <summary>
+    /// 请求滚动到顶部.
+    /// </summary>
+    public event EventHandler RequestScrollToTop;
 
     /// <summary>
     /// 筛选条件.

--- a/src/ViewModels/Views/VideoPartitionDetailViewModel/VideoPartitionDetailViewModel.Properties.cs
+++ b/src/ViewModels/Views/VideoPartitionDetailViewModel/VideoPartitionDetailViewModel.Properties.cs
@@ -60,11 +60,6 @@ public sealed partial class VideoPartitionDetailViewModel
     public ObservableCollection<Partition> SubPartitions { get; }
 
     /// <summary>
-    /// 推荐分区集合.
-    /// </summary>
-    public ObservableCollection<Partition> RecommendPartitions { get; }
-
-    /// <summary>
     /// 排序方式集合.
     /// </summary>
     public ObservableCollection<VideoSortType> SortTypes { get; }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

修复影视没有正确根据索引筛选条件排序的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

影视页面，无法通过索引筛选条件排序

## 新的行为是什么？

修复这个问题

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

顺带修复PGC索引页面切换条件后没有重置滚动位置的问题，以及直播没有重置滚动问题
