### PR TITLE
修复全局播放速率会影响直播的问题

### DIFF
--- a/src/App/Controls/Modules/AnimeNavListModule.xaml
+++ b/src/App/Controls/Modules/AnimeNavListModule.xaml
@@ -104,20 +104,19 @@
         <!--  时间表  -->
         <Grid Grid.Row="2" Visibility="{x:Bind ViewModel.IsTimelineShown, Mode=OneWay}">
             <ScrollViewer
-                Padding="8,0"
+                Padding="12,0"
                 Style="{StaticResource PageScrollViewerStyle}"
                 Visibility="{x:Bind _timeline.IsReloading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                 <ItemsRepeater Margin="0,0,0,12" ItemsSource="{x:Bind _timeline.TimelineCollection}">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="items:TimelineItemViewModel">
                             <base:CardPanel
-                                Background="Transparent"
-                                BorderThickness="0"
+                                BorderBrush="Transparent"
                                 Click="OnTimelineItemClick"
                                 DataContext="{x:Bind}"
                                 IsChecked="{x:Bind IsSelected, Mode=OneWay}"
                                 IsEnableCheck="False">
-                                <Grid Padding="12,8">
+                                <Grid Padding="12">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="Auto" />
@@ -137,7 +136,7 @@
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                     <ItemsRepeater.Layout>
-                        <StackLayout Spacing="4" />
+                        <StackLayout Spacing="8" />
                     </ItemsRepeater.Layout>
                 </ItemsRepeater>
                 <animations:Implicit.ShowAnimations>

--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
@@ -97,7 +97,7 @@ public sealed partial class PlayerDetailViewModel
         });
 
         var isGlobal = SettingsToolkit.ReadLocalSetting(SettingNames.GlobalPlaybackRate, false);
-        if (!isGlobal)
+        if (!isGlobal || _videoType == VideoType.Live)
         {
             PlaybackRate = 1d;
         }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #221 

修复全局播放速率会影响直播的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

开启全局播放速率后，在视频播放中设置的播放速率会同步到直播

## 新的行为是什么？

直播时，播放速率强制设置为1

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
