### PR TITLE
修复重新唤醒应用后空白的问题

### DIFF
--- a/src/App/Forms/MainWindow.xaml.cs
+++ b/src/App/Forms/MainWindow.xaml.cs
@@ -62,7 +62,7 @@ public sealed partial class MainWindow : WindowBase, ITipWindow, IUserSpaceWindo
         MinHeight = 640;
 
         Activated += OnActivated;
-        Closed += OnClosedAsync;
+        Closed += OnClosed;
 
         MoveAndResize();
     }
@@ -377,7 +377,7 @@ public sealed partial class MainWindow : WindowBase, ITipWindow, IUserSpaceWindo
     private void OnActiveMainWindow(object sender, EventArgs e)
         => Activate();
 
-    private async void OnClosedAsync(object sender, WindowEventArgs args)
+    private void OnClosed(object sender, WindowEventArgs args)
     {
         foreach (var item in AppViewModel.Instance.DisplayWindows.ToArray())
         {
@@ -389,10 +389,7 @@ public sealed partial class MainWindow : WindowBase, ITipWindow, IUserSpaceWindo
 
         if (_appViewModel.IsOverlayShown && OverlayFrame.Content is not null)
         {
-            _ = OverlayFrame.Navigate(typeof(Page));
-
-            await Task.Delay(200);
-            OverlayFrame.Content = null;
+            _appViewModel.BackCommand.Execute(default);
         }
 
         SaveCurrentWindowStats();


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

在主窗口播放视频后，如果直接关闭应用，再从任务栏重新唤醒，会显示一片空白。这是因为 OverlayFrame 没有关闭的原因

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
