### PR TITLE
修复主窗口播放时的自动结束逻辑问题

### DIFF
--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
@@ -223,7 +223,16 @@ public sealed partial class PlayerDetailViewModel
 
     [RelayCommand]
     private void AutoCloseWindow()
-        => AttachedWindow.Close();
+    {
+        if (AttachedWindow.GetType().FullName.Contains("MainWindow"))
+        {
+            BackCommand.Execute(default);
+        }
+        else
+        {
+            AttachedWindow.Close();
+        }
+    }
 
     [RelayCommand]
     private void ClearSourceProgress()
@@ -409,7 +418,7 @@ public sealed partial class PlayerDetailViewModel
             var hdQuality = isLive ? 10000 : 116;
             formatId = Formats.Where(p => !p.IsLimited && p.Quality <= hdQuality).Max(p => p.Quality);
         }
-        else if(preferQuality == PreferQuality.UHDFirst)
+        else if (preferQuality == PreferQuality.UHDFirst)
         {
             var uhdQuality = isLive ? Formats.Max(p => p.Quality) : 120;
             formatId = Formats.Where(p => !p.IsLimited && p.Quality <= uhdQuality).Max(p => p.Quality);


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #328 

当主窗口播放时，播放完成自动关闭将会选择关闭播放器而不是关闭窗口

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
