### PR TITLE
修复 MPV 下载提示不完全的问题

### DIFF
--- a/src/App/Controls/AppContentDialog.cs
+++ b/src/App/Controls/AppContentDialog.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Bili Copilot. All rights reserved.
+
+using Bili.Copilot.ViewModels;
+
+namespace Bili.Copilot.App.Controls;
+
+/// <summary>
+/// 应用内容对话框.
+/// </summary>
+public class AppContentDialog : ContentDialog
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AppContentDialog"/> class.
+    /// </summary>
+    public AppContentDialog()
+    {
+        Opened += OnOpened;
+        Closing += OnClosing;
+    }
+
+    private void OnClosing(ContentDialog sender, ContentDialogClosingEventArgs args)
+        => AppViewModel.Instance.CurrentDialog = null;
+
+    private void OnOpened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+        => AppViewModel.Instance.CurrentDialog = this;
+}

--- a/src/App/Controls/CloseWindowTipDialog.xaml
+++ b/src/App/Controls/CloseWindowTipDialog.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentDialog
+<local:AppContentDialog
     x:Class="Bili.Copilot.App.Controls.CloseWindowTipDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -26,4 +26,4 @@
             Content="{ext:Locale Name=NeverAskMeAgain}"
             IsChecked="{x:Bind IsNeverAskChecked, Mode=TwoWay}" />
     </StackPanel>
-</ContentDialog>
+</local:AppContentDialog>

--- a/src/App/Controls/CloseWindowTipDialog.xaml.cs
+++ b/src/App/Controls/CloseWindowTipDialog.xaml.cs
@@ -7,7 +7,7 @@ namespace Bili.Copilot.App.Controls;
 /// <summary>
 /// Prompt dialog when closing the window.
 /// </summary>
-public sealed partial class CloseWindowTipDialog : ContentDialog
+public sealed partial class CloseWindowTipDialog : AppContentDialog
 {
     /// <summary>
     /// Dependency property for <see cref="IsNeverAskChecked"/>.

--- a/src/App/Controls/DebugDialog.xaml
+++ b/src/App/Controls/DebugDialog.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentDialog
+<local:AppContentDialog
     x:Class="Bili.Copilot.App.Controls.DebugDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -104,4 +104,4 @@
         <ProgressRing x:Name="LoadingRing" Style="{StaticResource PageProgressRingStyle}" />
     </Grid>
 
-</ContentDialog>
+</local:AppContentDialog>

--- a/src/App/Controls/DebugDialog.xaml.cs
+++ b/src/App/Controls/DebugDialog.xaml.cs
@@ -18,7 +18,7 @@ namespace Bili.Copilot.App.Controls;
 /// <summary>
 /// 用于显示调试信息的对话框.
 /// </summary>
-public sealed partial class DebugDialog : ContentDialog
+public sealed partial class DebugDialog : AppContentDialog
 {
     private readonly VideoType _type;
     private readonly string _id;

--- a/src/App/Controls/Settings/MpvSettingSection.xaml.cs
+++ b/src/App/Controls/Settings/MpvSettingSection.xaml.cs
@@ -21,6 +21,13 @@ public sealed partial class MpvSettingSection : SettingSection
 
     private async void OnDownloadButtonClickAsync(object sender, RoutedEventArgs e)
     {
+        var hasPwsh = await AppToolkit.CheckPwshAvailabilityAsync();
+        if (hasPwsh)
+        {
+            _appViewModel.ShowMessage(ResourceToolkit.GetLocalizedString(Models.Constants.App.StringNames.NeedDownloadPwsh));
+            return;
+        }
+
         _appViewModel.ShowMessage(ResourceToolkit.GetLocalizedString(Models.Constants.App.StringNames.DownloadMpvTip));
         await Task.Delay(2000);
         var folder = await FileToolkit.PickFolderAsync(_appViewModel.ActivatedWindow);

--- a/src/App/Controls/Settings/MpvSettingSection.xaml.cs
+++ b/src/App/Controls/Settings/MpvSettingSection.xaml.cs
@@ -22,7 +22,7 @@ public sealed partial class MpvSettingSection : SettingSection
     private async void OnDownloadButtonClickAsync(object sender, RoutedEventArgs e)
     {
         var hasPwsh = await AppToolkit.CheckPwshAvailabilityAsync();
-        if (hasPwsh)
+        if (!hasPwsh)
         {
             _appViewModel.ShowMessage(ResourceToolkit.GetLocalizedString(Models.Constants.App.StringNames.NeedDownloadPwsh));
             return;

--- a/src/App/Controls/TipDialog.xaml
+++ b/src/App/Controls/TipDialog.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentDialog
+<local:AppContentDialog
     x:Class="Bili.Copilot.App.Controls.TipDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -17,6 +17,7 @@
         <TextBlock
             x:Name="TipBlock"
             MaxWidth="320"
+            IsTextSelectionEnabled="True"
             TextWrapping="Wrap" />
     </Grid>
-</ContentDialog>
+</local:AppContentDialog>

--- a/src/App/Controls/TipDialog.xaml.cs
+++ b/src/App/Controls/TipDialog.xaml.cs
@@ -7,7 +7,7 @@ namespace Bili.Copilot.App.Controls;
 /// <summary>
 /// Tip dialog.
 /// </summary>
-public sealed partial class TipDialog : ContentDialog
+public sealed partial class TipDialog : AppContentDialog
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="TipDialog"/> class.

--- a/src/App/Controls/UpdateDialog.xaml
+++ b/src/App/Controls/UpdateDialog.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentDialog
+<local:AppContentDialog
     x:Class="Bili.Copilot.App.Controls.UpdateDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -62,4 +62,4 @@
                 Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
         </ScrollViewer>
     </Grid>
-</ContentDialog>
+</local:AppContentDialog>

--- a/src/App/Controls/UpdateDialog.xaml.cs
+++ b/src/App/Controls/UpdateDialog.xaml.cs
@@ -10,7 +10,7 @@ namespace Bili.Copilot.App.Controls;
 /// <summary>
 /// 应用更新对话框.
 /// </summary>
-public sealed partial class UpdateDialog : ContentDialog
+public sealed partial class UpdateDialog : AppContentDialog
 {
     private readonly UpdateEventArgs _eventArgs;
 

--- a/src/App/Controls/WebDavConfigDialog.xaml
+++ b/src/App/Controls/WebDavConfigDialog.xaml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentDialog
+<local:AppContentDialog
     x:Class="Bili.Copilot.App.Controls.WebDavConfigDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -40,4 +40,4 @@
             HorizontalAlignment="Stretch"
             Header="{ext:Locale Name=Password}" />
     </StackPanel>
-</ContentDialog>
+</local:AppContentDialog>

--- a/src/App/Controls/WebDavConfigDialog.xaml.cs
+++ b/src/App/Controls/WebDavConfigDialog.xaml.cs
@@ -9,7 +9,7 @@ namespace Bili.Copilot.App.Controls;
 /// <summary>
 /// WebDav 配置对话框.
 /// </summary>
-public sealed partial class WebDavConfigDialog : ContentDialog
+public sealed partial class WebDavConfigDialog : AppContentDialog
 {
     private readonly WebDavConfig _source;
     private readonly SettingsPageViewModel _pageVM;

--- a/src/App/Forms/MainWindow.xaml.cs
+++ b/src/App/Forms/MainWindow.xaml.cs
@@ -185,6 +185,8 @@ public sealed partial class MainWindow : WindowBase, ITipWindow, IUserSpaceWindo
         {
             XamlRoot = Content.XamlRoot,
         };
+
+        AppViewModel.Instance.CurrentDialog?.Hide();
         _ = await dialog.ShowAsync();
     }
 
@@ -194,6 +196,8 @@ public sealed partial class MainWindow : WindowBase, ITipWindow, IUserSpaceWindo
         {
             XamlRoot = Content.XamlRoot,
         };
+
+        AppViewModel.Instance.CurrentDialog?.Hide();
         _ = await dialog.ShowAsync();
     }
 

--- a/src/App/Resources/zh-Hans/Resources.resw
+++ b/src/App/Resources/zh-Hans/Resources.resw
@@ -2349,4 +2349,7 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   <data name="UseMpvPlayerDescription" xml:space="preserve">
     <value>使用 MPV 作为外部播放器播放 BiliBili 视频</value>
   </data>
+  <data name="NeedDownloadPwsh" xml:space="preserve">
+    <value>安装脚本需要 PowerShell 才能运行（不是设备预装的 Windows PowerShell），请先在设备上安装 PowerShell，你可以在微软商店搜索 PowerShell 下载安装。安装完成后重启应用，再尝试点击按钮下载 mpv</value>
+  </data>
 </root>

--- a/src/App/Resources/zh-Hant/Resources.resw
+++ b/src/App/Resources/zh-Hant/Resources.resw
@@ -2328,4 +2328,7 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集視頻 &gt; 關聯視頻 (如�
   <data name="UseMpvPlayerDescription" xml:space="preserve">
     <value>使用 MPV 作為外部播放機播放 BiliBili 影片</value>
   </data>
+  <data name="NeedDownloadPwsh" xml:space="preserve">
+    <value>安裝腳本需要 PowerShell 才能運行（不是設備預裝的 Windows PowerShell），請先在設備上安裝 PowerShell，你可以在微軟商店搜索 PowerShell 下載安裝。 安裝完成後重啟應用，再嘗試點擊按鈕下載 mpv</value>
+  </data>
 </root>

--- a/src/Libs/Libs.Provider/AuthorizeProvider/AuthorizeProvider.Extension.cs
+++ b/src/Libs/Libs.Provider/AuthorizeProvider/AuthorizeProvider.Extension.cs
@@ -420,7 +420,7 @@ public partial class AuthorizeProvider
                 AccessToken = data[Settings.AccessTokenKey].ToString(),
                 RefreshToken = data[Settings.RefreshTokenKey].ToString(),
                 Mid = Convert.ToInt64(data[Settings.UserIdKey]),
-                ExpiresIn = (long)data[Settings.ExpiresInKey],
+                ExpiresIn = Convert.ToInt64(data[Settings.ExpiresInKey]),
             };
 
             CurrentUserId = tokenInfo.Mid.ToString();

--- a/src/Libs/Libs.Toolkit/AppToolkit.cs
+++ b/src/Libs/Libs.Toolkit/AppToolkit.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Bili.Copilot.Models.Constants.App;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
@@ -192,5 +194,33 @@ public static class AppToolkit
         }
 
         return server;
+    }
+
+    /// <summary>
+    /// 检查是否安装了 PowerShell.
+    /// </summary>
+    /// <returns>是否安装.</returns>
+    public static async Task<bool> CheckPwshAvailabilityAsync()
+    {
+        var process = new Process();
+        process.StartInfo.FileName = "pwsh.exe";
+        process.StartInfo.Arguments = "--version";
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.CreateNoWindow = true;
+
+        try
+        {
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            await process.WaitForExitAsync();
+
+            return !string.IsNullOrEmpty(output) && output.StartsWith("PowerShell");
+        }
+        catch
+        {
+            return false;
+        }
     }
 }

--- a/src/ViewModels/Components/AppViewModel/AppViewModel.Properties.cs
+++ b/src/ViewModels/Components/AppViewModel/AppViewModel.Properties.cs
@@ -14,6 +14,7 @@ using Bili.Copilot.ViewModels.Items;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Bili.Copilot.ViewModels;
 
@@ -192,6 +193,11 @@ public sealed partial class AppViewModel
     /// 显示的窗口列表.
     /// </summary>
     public List<Window> DisplayWindows { get; }
+
+    /// <summary>
+    /// 当前显示的对话框.
+    /// </summary>
+    public ContentDialog CurrentDialog { get; set; }
 
     /// <summary>
     /// 是否显示 Web DAV.


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

MPV 安装脚本依赖 PowerShell，这一点没有很好地提示用户，导致出现一些点击下载按钮无响应的 bug。

现在会在用户设备上没有安装 PowerShell 时给出提示

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
