### PR TITLE
修复在多 P 视频下，倍速选项会消失的问题

### DIFF
--- a/src/App/Controls/Base/BiliTransportControls.xaml
+++ b/src/App/Controls/Base/BiliTransportControls.xaml
@@ -266,7 +266,7 @@
                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                         Style="{StaticResource CaptionTextBlockStyle}"
                                         Text="{ext:Locale Name=PlaybackRate}" />
-                                    <ItemsRepeater ItemsSource="{x:Bind ViewModel.PlaybackRates}">
+                                    <ItemsRepeater ItemsSource="{x:Bind ViewModel.PlaybackRates, Mode=OneWay}">
                                         <ItemsRepeater.Layout>
                                             <StackLayout Orientation="Horizontal" Spacing="4" />
                                         </ItemsRepeater.Layout>

--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
@@ -54,7 +54,6 @@ public sealed partial class PlayerDetailViewModel
     private void ResetMediaData()
     {
         TryClear(Formats);
-        TryClear(PlaybackRates);
         IsShowProgressTip = false;
         IsShowMediaTransport = false;
         IsShowAutoCloseWindowTip = false;

--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Properties.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Properties.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Windows.Documents;
 using Bili.Copilot.Models.App.Other;
 using Bili.Copilot.Models.Constants.App;
 using Bili.Copilot.Models.Constants.Bili;

--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.cs
@@ -375,7 +375,6 @@ public sealed partial class PlayerDetailViewModel : ViewModelBase, IDisposable
 
                 Clear();
                 Formats.Clear();
-                PlaybackRates.Clear();
             }
 
             _disposedValue = true;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #372 

在多P下，切换分P会导致当前播放资源释放，这会重置播放速率选项，但实际上这是不必要的。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
