### PR TITLE
为应用处理备用流链接和排除 P2P 节点的能力

### DIFF
--- a/src/App/Controls/Settings/PlayerControlSettingSection.xaml
+++ b/src/App/Controls/Settings/PlayerControlSettingSection.xaml
@@ -104,6 +104,9 @@
             <labs:SettingsCard Description="{ext:Locale Name=PlaybackRateSliderEnabledDescription}" Header="{ext:Locale Name=PlaybackRateSliderEnabled}">
                 <ToggleSwitch IsOn="{x:Bind ViewModel.IsPlaybackRateSliderVisible, Mode=TwoWay}" />
             </labs:SettingsCard>
+            <labs:SettingsCard Description="{ext:Locale Name=NoP2PDescription}" Header="{ext:Locale Name=NoP2P}">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.NoP2P, Mode=TwoWay}" />
+            </labs:SettingsCard>
         </labs:SettingsExpander.Items>
     </labs:SettingsExpander>
 </local:SettingSection>

--- a/src/App/Resources/zh-Hans/Resources.resw
+++ b/src/App/Resources/zh-Hans/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2351,5 +2351,11 @@ UGC优先级：分P &gt; 播放列表 &gt; 合集视频 &gt; 关联视频 (如�
   </data>
   <data name="NeedDownloadPwsh" xml:space="preserve">
     <value>安装脚本需要 PowerShell 才能运行（不是设备预装的 Windows PowerShell），请先在设备上安装 PowerShell，你可以在微软商店搜索 PowerShell 下载安装。安装完成后重启应用，再尝试点击按钮下载 mpv</value>
+  </data>
+  <data name="NoP2P" xml:space="preserve">
+    <value>不使用 P2P 节点</value>
+  </data>
+  <data name="NoP2PDescription" xml:space="preserve">
+    <value>将会尝试使用从非 MCDN/PCDN 节点获取视频和音频流</value>
   </data>
 </root>

--- a/src/App/Resources/zh-Hant/Resources.resw
+++ b/src/App/Resources/zh-Hant/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2330,5 +2330,11 @@ UGC優先級：分P &gt; 播放列表 &gt; 合集視頻 &gt; 關聯視頻 (如�
   </data>
   <data name="NeedDownloadPwsh" xml:space="preserve">
     <value>安裝腳本需要 PowerShell 才能運行（不是設備預裝的 Windows PowerShell），請先在設備上安裝 PowerShell，你可以在微軟商店搜索 PowerShell 下載安裝。 安裝完成後重啟應用，再嘗試點擊按鈕下載 mpv</value>
+  </data>
+  <data name="NoP2P" xml:space="preserve">
+    <value>不使用 P2P 節點</value>
+  </data>
+  <data name="NoP2PDescription" xml:space="preserve">
+    <value>將會嚐試使用從非 MCDN/PCDN 節點獲取視頻和音頻流</value>
   </data>
 </root>

--- a/src/Libs/Libs.Adapter/Libs.Adapter.csproj
+++ b/src/Libs/Libs.Adapter/Libs.Adapter.csproj
@@ -5,6 +5,8 @@
       <RootNamespace>Bili.Copilot.Libs.Adapter</RootNamespace>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libs/Libs.Flyleaf/Libs.Flyleaf.csproj
+++ b/src/Libs/Libs.Flyleaf/Libs.Flyleaf.csproj
@@ -8,6 +8,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libs/Libs.Provider/HttpProvider/HttpProvider.cs
+++ b/src/Libs/Libs.Provider/HttpProvider/HttpProvider.cs
@@ -56,7 +56,7 @@ public sealed partial class HttpProvider
     {
         FlurlRequest requestMessage;
 
-        if (needCsrf && !queryParams.ContainsKey("csrf"))
+        if (needCsrf && queryParams != null && !queryParams.ContainsKey("csrf"))
         {
             queryParams.Add("csrf", AuthorizeProvider.GetCsrfToken());
         }

--- a/src/Libs/Libs.Provider/Libs.Provider.csproj
+++ b/src/Libs/Libs.Provider/Libs.Provider.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>Bili.Copilot.Libs.Provider</RootNamespace>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libs/Libs.ResourceGenerator/Libs.ResourceGenerator.csproj
+++ b/src/Libs/Libs.ResourceGenerator/Libs.ResourceGenerator.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <EnableMsixTooling>true</EnableMsixTooling>
+        <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Libs/Libs.Toolkit/Libs.Toolkit.csproj
+++ b/src/Libs/Libs.Toolkit/Libs.Toolkit.csproj
@@ -5,6 +5,8 @@
         <RootNamespace>Bili.Copilot.Libs.Toolkit</RootNamespace>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <UseWinUI>true</UseWinUI>
+        <EnableMsixTooling>true</EnableMsixTooling>
+        <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Models/Models.Constants/App/SettingNames.cs
+++ b/src/Models/Models.Constants/App/SettingNames.cs
@@ -145,4 +145,5 @@ public enum SettingNames
     BottomProgressVisible,
     PlaybackRateSliderEnabled,
     UseMpvPlayer,
+    NoP2P,
 }

--- a/src/ViewModels/Components/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/Components/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -111,9 +111,10 @@ public sealed partial class NativePlayerViewModel
         var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(mpdFilePath));
         var mpdStr = await FileIO.ReadTextAsync(file);
 
+        var videoUrl = await PlayerProvider.GetAvailableUrlAsync([_video.BaseUrl, .._video.BackupUrls]);
         var videoStr =
                 $@"<Representation bandwidth=""{_video.Bandwidth}"" codecs=""{_video.Codecs}"" height=""{_video.Height}"" mimeType=""{_video.MimeType}"" id=""{_video.Id}"" width=""{_video.Width}"" startWithSap=""{_video.StartWithSap}"">
-                               <BaseURL>{SecurityElement.Escape(_video.BaseUrl)}</BaseURL>
+                               <BaseURL>{SecurityElement.Escape(videoUrl)}</BaseURL>
                                <SegmentBase indexRange=""{_video.IndexRange}"">
                                    <Initialization range=""{_video.Initialization}"" />
                                </SegmentBase>
@@ -123,9 +124,10 @@ public sealed partial class NativePlayerViewModel
 
         if (_audio != null)
         {
+            var audioUrl = await PlayerProvider.GetAvailableUrlAsync([_audio.BaseUrl, .._audio.BackupUrls]);
             audioStr =
                     $@"<Representation bandwidth=""{_audio.Bandwidth}"" codecs=""{_audio.Codecs}"" mimeType=""{_audio.MimeType}"" id=""{_audio.Id}"">
-                               <BaseURL>{SecurityElement.Escape(_audio.BaseUrl)}</BaseURL>
+                               <BaseURL>{SecurityElement.Escape(audioUrl)}</BaseURL>
                                <SegmentBase indexRange=""{_audio.IndexRange}"">
                                    <Initialization range=""{_audio.Initialization}"" />
                                </SegmentBase>

--- a/src/ViewModels/Components/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
+++ b/src/ViewModels/Components/NativePlayerViewModel/NativePlayerViewModel.Methods.cs
@@ -111,10 +111,9 @@ public sealed partial class NativePlayerViewModel
         var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(mpdFilePath));
         var mpdStr = await FileIO.ReadTextAsync(file);
 
-        var videoUrl = await PlayerProvider.GetAvailableUrlAsync([_video.BaseUrl, .._video.BackupUrls]);
         var videoStr =
                 $@"<Representation bandwidth=""{_video.Bandwidth}"" codecs=""{_video.Codecs}"" height=""{_video.Height}"" mimeType=""{_video.MimeType}"" id=""{_video.Id}"" width=""{_video.Width}"" startWithSap=""{_video.StartWithSap}"">
-                               <BaseURL>{SecurityElement.Escape(videoUrl)}</BaseURL>
+                               <BaseURL>{SecurityElement.Escape(_video.BaseUrl)}</BaseURL>
                                <SegmentBase indexRange=""{_video.IndexRange}"">
                                    <Initialization range=""{_video.Initialization}"" />
                                </SegmentBase>
@@ -124,10 +123,9 @@ public sealed partial class NativePlayerViewModel
 
         if (_audio != null)
         {
-            var audioUrl = await PlayerProvider.GetAvailableUrlAsync([_audio.BaseUrl, .._audio.BackupUrls]);
             audioStr =
                     $@"<Representation bandwidth=""{_audio.Bandwidth}"" codecs=""{_audio.Codecs}"" mimeType=""{_audio.MimeType}"" id=""{_audio.Id}"">
-                               <BaseURL>{SecurityElement.Escape(audioUrl)}</BaseURL>
+                               <BaseURL>{SecurityElement.Escape(_audio.BaseUrl)}</BaseURL>
                                <SegmentBase indexRange=""{_audio.IndexRange}"">
                                    <Initialization range=""{_audio.Initialization}"" />
                                </SegmentBase>

--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Method.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Bili.Copilot.Libs.Provider;
 using Bili.Copilot.Libs.Toolkit;
@@ -25,6 +26,11 @@ namespace Bili.Copilot.ViewModels;
 /// </summary>
 public sealed partial class PlayerDetailViewModel
 {
+    private readonly Regex _p2PRegex = P2PRegex();
+
+    [GeneratedRegex("(mcdn.bilivideo.(cn|com)|szbdyd.com)")]
+    private static partial Regex P2PRegex();
+
     private static string GetVideoPreferCodecId()
     {
         var preferCodec = SettingsToolkit.ReadLocalSetting(SettingNames.PreferCodec, PreferCodec.H264);
@@ -444,5 +450,11 @@ public sealed partial class PlayerDetailViewModel
         }
 
         return formatId;
+    }
+
+    private bool IsP2PUrl(string url)
+    {
+        var uri = new Uri(url);
+        return _p2PRegex.IsMatch(uri.Host);
     }
 }

--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Video.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Video.cs
@@ -147,6 +147,9 @@ public sealed partial class PlayerDetailViewModel
                     ?? filteredSegments.First();
             }
 
+            // 使用响应里有效的 URL
+            _video.BaseUrl = await PlayerProvider.GetAvailableUrlAsync([_video.BaseUrl, .._video.BackupUrls]);
+
             CurrentFormat = Formats.FirstOrDefault(p => p.Quality.ToString() == _video.Id);
             SettingsToolkit.WriteLocalSetting(SettingNames.DefaultVideoFormat, CurrentFormat.Quality);
         }
@@ -168,6 +171,9 @@ public sealed partial class PlayerDetailViewModel
                 _audio = _mediaInformation.AudioSegments.Where(p => p.Bandwidth < 100000).FirstOrDefault()
                     ?? _mediaInformation.AudioSegments.OrderBy(p => p.Bandwidth).First();
             }
+
+            // 使用响应里有效的 URL
+            _audio.BaseUrl = await PlayerProvider.GetAvailableUrlAsync([_audio.BaseUrl, .._audio.BackupUrls]);
         }
 
         if (_video == null)

--- a/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Video.cs
+++ b/src/ViewModels/Components/PlayerDetailViewModel/PlayerDetailViewModel.Video.cs
@@ -148,7 +148,16 @@ public sealed partial class PlayerDetailViewModel
             }
 
             // 使用响应里有效的 URL
-            _video.BaseUrl = await PlayerProvider.GetAvailableUrlAsync([_video.BaseUrl, .._video.BackupUrls]);
+#pragma warning disable SA1010
+            string[] videoUrls = [_video.BaseUrl, .._video.BackupUrls];
+#pragma warning restore SA1010
+
+            if (SettingsToolkit.ReadLocalSetting(SettingNames.NoP2P, false))
+            {
+                videoUrls = videoUrls.Where(url => !IsP2PUrl(url)).ToArray();
+            }
+
+            _video.BaseUrl = await PlayerProvider.GetAvailableUrlAsync(videoUrls);
 
             CurrentFormat = Formats.FirstOrDefault(p => p.Quality.ToString() == _video.Id);
             SettingsToolkit.WriteLocalSetting(SettingNames.DefaultVideoFormat, CurrentFormat.Quality);
@@ -172,8 +181,16 @@ public sealed partial class PlayerDetailViewModel
                     ?? _mediaInformation.AudioSegments.OrderBy(p => p.Bandwidth).First();
             }
 
+#pragma warning disable SA1010
+            string[] audioUrls = [_audio.BaseUrl, .._audio.BackupUrls];
+#pragma warning restore SA1010
+            if (SettingsToolkit.ReadLocalSetting(SettingNames.NoP2P, false))
+            {
+                audioUrls = audioUrls.Where(url => !IsP2PUrl(url)).ToArray();
+            }
+
             // 使用响应里有效的 URL
-            _audio.BaseUrl = await PlayerProvider.GetAvailableUrlAsync([_audio.BaseUrl, .._audio.BackupUrls]);
+            _audio.BaseUrl = await PlayerProvider.GetAvailableUrlAsync(audioUrls);
         }
 
         if (_video == null)

--- a/src/ViewModels/ViewModels.csproj
+++ b/src/ViewModels/ViewModels.csproj
@@ -7,6 +7,8 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <UseWinUI>true</UseWinUI>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableCoreMrtTooling Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Components\VlcPlayerViewModel\**" />

--- a/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
+++ b/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
@@ -153,6 +153,9 @@ public sealed partial class SettingsPageViewModel
     [ObservableProperty]
     private bool _isPlaybackRateSliderVisible;
 
+    [ObservableProperty]
+    private bool _noP2P;
+
     /// <summary>
     /// 播放器显示模式可选集合.
     /// </summary>

--- a/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.cs
+++ b/src/ViewModels/Views/SettingsPageViewModel/SettingsPageViewModel.cs
@@ -63,6 +63,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
         BottomProgressVisible = ReadSetting(SettingNames.BottomProgressVisible, true);
         IsPlaybackRateSliderVisible = ReadSetting(SettingNames.PlaybackRateSliderEnabled, false);
         UseMpvPlayer = ReadSetting(SettingNames.UseMpvPlayer, false);
+        NoP2P = ReadSetting(SettingNames.NoP2P, false);
         WebPlayerInit();
         PreferCodecInit();
         DecodeInit();
@@ -229,6 +230,9 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
                 break;
             case nameof(IsPlaybackRateSliderVisible):
                 WriteSetting(SettingNames.PlaybackRateSliderEnabled, IsPlaybackRateSliderVisible);
+                break;
+            case nameof(NoP2P):
+                WriteSetting(SettingNames.NoP2P, NoP2P);
                 break;
             default:
                 break;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

- close #423 - 解决处理备用流链接的问题
- close #422 - 本地环境复现，与 #423 原因一致
- close #424 - 由于需要修改处理备用流链接的逻辑，所以于此 PR 一同解决

<!-- 在上面的 `Close` 标题后添加要修复的 Issue 编号，比如 “Close #1234”，这样在 PR 合并后可以直接关闭 Issue -->

- 同时修复了 HttpProvider.GetRequestMessageAsync 方法缺少 queryParams 参数时会引发空引用异常的问题（因为选择 URL 的逻辑需要修复这个问题）
- 修复了非 Visual Studio 的 IDE 和工具链会构建失败的问题，因为在我这不修这个问题编译都过不去...

<!-- 在此添加对修复的问题或添加的功能的简要描述 -->

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

应用在 API 返回的 BaseUrl 不可用时不会切换到 BackupUrls，导致播放失败或无限加载，详见 #423 #422。

## 新的行为是什么？

- 应用会在 BaseUrl 不可用时使用 BackupUrls 中可用的 Url 替换 BaseUrl。
- 当用户设置 “不使用 P2P 节点” 时将 BaseUrl 替换为 Host 不与正则表达式 `(mcdn.bilivideo.(cn|com)|szbdyd.com)` 不匹配的 Url。

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
