### PR TITLE
修复弹幕在高缩放下的模糊问题

### DIFF
--- a/src/Libs/Danmaku.Core/DanmakuRender.cs
+++ b/src/Libs/Danmaku.Core/DanmakuRender.cs
@@ -47,6 +47,7 @@ namespace Danmaku.Core
         private volatile float _rollingAreaRatio = 0.8f;
         private volatile float _rollingSpeed = Default_Rolling_Speed; // 1 to 10
         private double _textOpacity = 1.0;
+        private float _scale = 1.0f;
         private Color _borderColor = Colors.Blue;
         private string _defaultFontFamilyName = Default_Font_Family_Name;
 
@@ -72,8 +73,10 @@ namespace Danmaku.Core
 
             _canvas.IsFixedTimeStep = false;
             _dpi = _canvas.Dpi;
-            CanvasWidth = (float)_canvas.ActualWidth;
-            CanvasHeight = (float)_canvas.ActualHeight;
+            _scale = (float)_canvas.XamlRoot.RasterizationScale;
+            CanvasWidth = (float)_canvas.ActualWidth * _scale;
+            CanvasHeight = (float)_canvas.ActualHeight * _scale;
+            _rollingSpeed = Default_Rolling_Speed * _scale;
 
             _canvas.SizeChanged += CanvasAnimatedControl_SizeChanged;
             _canvas.CreateResources += CanvasAnimatedControl_CreateResources;
@@ -124,7 +127,7 @@ namespace Danmaku.Core
         {
             if (value >= 1 && value <= 10)
             {
-                _rollingSpeed = value * 0.02f;
+                _rollingSpeed = value * 0.02f * _scale;
             }
         }
 
@@ -249,6 +252,8 @@ namespace Danmaku.Core
                         }
                     }
                     textFormat.FontSize = (int)Math.Max(textFormat.FontSize, 2f);
+
+                    textFormat.FontSize = textFormat.FontSize * _scale;
 
                     if (!string.IsNullOrWhiteSpace(renderItem.FontFamilyName))
                     {
@@ -643,8 +648,8 @@ namespace Danmaku.Core
 
         private void CanvasAnimatedControl_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            CanvasWidth = (float)e.NewSize.Width;
-            CanvasHeight = (float)e.NewSize.Height;
+            CanvasWidth = (float)e.NewSize.Width * _scale;
+            CanvasHeight = (float)e.NewSize.Height * _scale;
             for (int i = 0; i < _renderLayerList.Length; i++)
             {
                 _renderLayerList[i].UpdateYSlotManagerLength((uint)e.NewSize.Height, _rollingAreaRatio);
@@ -822,6 +827,7 @@ namespace Danmaku.Core
             try
             {
                 int totalCount = 0;
+                args.DrawingSession.Transform = new Matrix3x2 { M11 = 1f / _scale, M22 = 1f / _scale };
 
                 for (uint layerId = 0; layerId < _renderLayerList.Length; layerId++)
                 {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #514 

弹幕同样使用 DX 渲染，但是画布没有做倍率缩放调整，导致在高分屏高缩放比例下存在肉眼可见的模糊。

修复方式时针对画布进行符合当前系统缩放比例的放大，然后在渲染时再等比缩小以适应视窗，这样就可以保证渲染效果清晰锐利。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
