### PR TITLE
修复稍后再看的播放全部不工作，视频收藏夹新增播放当前列表

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Favorites/VideoFavoriteHeader.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Favorites/VideoFavoriteHeader.xaml
@@ -28,20 +28,38 @@
                 Value="{x:Bind ViewModel.TotalCount, Mode=OneWay}" />
         </StackPanel>
 
-        <Button
+        <StackPanel
             Grid.Column="2"
             VerticalAlignment="Center"
-            AutomationProperties.Name="{ext:Locale Name=Refresh}"
-            Command="{x:Bind ViewModel.RefreshCommand, Mode=OneWay}"
-            IsEnabled="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource ObjectToBoolReverseConverter}}">
-            <StackPanel Orientation="Horizontal" Spacing="8">
-                <ic:SymbolIcon
-                    VerticalAlignment="Center"
-                    FontSize="12"
-                    Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                    Symbol="ArrowSync" />
-                <TextBlock VerticalAlignment="Center" Text="{ext:Locale Name=Refresh}" />
-            </StackPanel>
-        </Button>
+            Orientation="Horizontal"
+            Spacing="8">
+            <Button
+                VerticalAlignment="Center"
+                AutomationProperties.Name="{ext:Locale Name=PlayCurrentList}"
+                Command="{x:Bind ViewModel.PlayCurrentListCommand, Mode=OneWay}"
+                IsEnabled="{x:Bind ViewModel.IsEmpty, Mode=OneWay, Converter={StaticResource ObjectToBoolReverseConverter}}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <ic:SymbolIcon
+                        VerticalAlignment="Center"
+                        FontSize="12"
+                        Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                        Symbol="NavigationPlay" />
+                    <TextBlock VerticalAlignment="Center" Text="{ext:Locale Name=PlayCurrentList}" />
+                </StackPanel>
+            </Button>
+            <Button
+                AutomationProperties.Name="{ext:Locale Name=Refresh}"
+                Command="{x:Bind ViewModel.RefreshCommand, Mode=OneWay}"
+                IsEnabled="{x:Bind ViewModel.IsLoading, Mode=OneWay, Converter={StaticResource ObjectToBoolReverseConverter}}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <ic:SymbolIcon
+                        VerticalAlignment="Center"
+                        FontSize="12"
+                        Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                        Symbol="ArrowSync" />
+                    <TextBlock VerticalAlignment="Center" Text="{ext:Locale Name=Refresh}" />
+                </StackPanel>
+            </Button>
+        </StackPanel>
     </Grid>
 </local:VideoFavoriteControlBase>

--- a/src/Desktop/BiliCopilot.UI/Controls/ViewLater/ViewLaterHeader.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/ViewLater/ViewLaterHeader.xaml
@@ -51,6 +51,7 @@
             <Button
                 VerticalAlignment="Center"
                 AutomationProperties.Name="{ext:Locale Name=PlayAll}"
+                Command="{x:Bind ViewModel.PlayAllCommand}"
                 IsEnabled="{x:Bind ViewModel.IsEmpty, Mode=OneWay, Converter={StaticResource ObjectToBoolReverseConverter}}">
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <ic:SymbolIcon

--- a/src/Desktop/BiliCopilot.UI/Resources/zh-Hans-CN/Resources.resw
+++ b/src/Desktop/BiliCopilot.UI/Resources/zh-Hans-CN/Resources.resw
@@ -2645,4 +2645,7 @@
   <data name="AlreadyPinned" xml:space="preserve">
     <value>该条目已经固定过，请在固定列表中查看</value>
   </data>
+  <data name="PlayCurrentList" xml:space="preserve">
+    <value>播放当前列表</value>
+  </data>
 </root>

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoFavoriteSectionDetailViewModel/VideoFavoriteSectionDetailViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoFavoriteSectionDetailViewModel/VideoFavoriteSectionDetailViewModel.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using BiliCopilot.UI.Models;
+using BiliCopilot.UI.Pages.Overlay;
+using BiliCopilot.UI.ViewModels.Core;
 using BiliCopilot.UI.ViewModels.Items;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
@@ -93,6 +96,21 @@ public sealed partial class VideoFavoriteSectionDetailViewModel : ViewModelBase<
         {
             IsEmpty = Items.Count == 0;
             IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private void PlayCurrentList()
+    {
+        if (Items.Count == 1)
+        {
+            var video = Items.First();
+            this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage).FullName, new VideoSnapshot(video.Data));
+        }
+        else
+        {
+            var data = (Items.Select(p => p.Data).ToList(), new VideoSnapshot(Items.First().Data));
+            this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage).FullName, data);
         }
     }
 

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/ViewLaterPageViewModel/ViewLaterPageViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/ViewLaterPageViewModel/ViewLaterPageViewModel.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using BiliCopilot.UI.Models;
+using BiliCopilot.UI.Pages.Overlay;
+using BiliCopilot.UI.ViewModels.Core;
 using BiliCopilot.UI.ViewModels.Items;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
@@ -101,6 +104,20 @@ public sealed partial class ViewLaterPageViewModel : ViewModelBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "清除稍后再看时出错");
+        }
+    }
+
+    [RelayCommand]
+    private void PlayAll()
+    {
+        if (Videos.Count == 1)
+        {
+            this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage).FullName, new VideoSnapshot(Videos.First().Data));
+        }
+        else
+        {
+            var data = (Videos.Select(p => p.Data).ToList(), new VideoSnapshot(Videos.First().Data));
+            this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage).FullName, data);
         }
     }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #519 

1. 修复稍后再看中 `播放全部` 按钮点击无效的问题（忘了写这个功能了）
2. 在视频收藏夹中增加 `播放当前列表`。因为视频收藏夹内容是增量加载的，所以点击这个按钮只会将已加载的视频作为列表进行播放

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
