### PR TITLE
主体内容切换回 ScrollViewer 以解决滚动缓慢的问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Article/ArticlePartitionMainBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Article/ArticlePartitionMainBody.xaml
@@ -11,10 +11,10 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView
+        <ScrollViewer
             x:Name="ArticleScrollView"
             Grid.Row="1"
-            Style="{StaticResource PageScrollViewStyle}">
+            Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Articles, Mode=OneWay}" Layout="{StaticResource ArticleLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -24,7 +24,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
         <components:LoadingWidget Grid.Row="1" Visibility="{x:Bind ViewModel.IsArticleLoading, Mode=OneWay}" />
     </Grid>
 </local:ArticlePartitionDetailControlBase>

--- a/src/Desktop/BiliCopilot.UI/Controls/Article/ArticlePartitionMainBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Article/ArticlePartitionMainBody.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class ArticlePartitionMainBody : ArticlePartitionDetailCon
         CheckArticleCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentDetailPanel.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentDetailPanel.xaml
@@ -16,10 +16,10 @@
             <RowDefinition />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <ScrollView
+        <ScrollViewer
             x:Name="CommentScrollView"
             Padding="0"
-            Style="{StaticResource PageScrollViewStyle}">
+            Style="{StaticResource PageScrollViewerStyle}">
             <StackPanel Margin="12,0" Spacing="12">
                 <components:CommentItemControl IsMoreEnabled="False" ViewModel="{x:Bind ViewModel.Data, Mode=OneWay}" />
                 <ItemsControl ItemsSource="{x:Bind ViewModel.Comments, Mode=OneWay}">
@@ -30,7 +30,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </StackPanel>
-        </ScrollView>
+        </ScrollViewer>
         <components:EmptyHolder
             Description="{ext:Locale Name=NoReply}"
             Emoji="&#x1FAE2;"

--- a/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentDetailPanel.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentDetailPanel.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class CommentDetailPanel : CommentDetailPanelBase
         CheckCommentCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentMainPanel.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentMainPanel.xaml
@@ -55,10 +55,10 @@
             Content="{ext:Locale Name=BackToPrevious}"
             Visibility="{x:Bind ViewModel.SelectedItem, Mode=OneWay, Converter={StaticResource ObjectToVisibilityConverter}}" />
         <Grid Grid.Row="1" Visibility="{x:Bind ViewModel.SelectedItem, Mode=OneWay, Converter={StaticResource ObjectToVisibilityReverseConverter}}">
-            <ScrollView
+            <ScrollViewer
                 x:Name="CommentScrollView"
                 Padding="0"
-                Style="{StaticResource PageScrollViewStyle}">
+                Style="{StaticResource PageScrollViewerStyle}">
                 <Grid Margin="12,0">
                     <ItemsControl ItemsSource="{x:Bind ViewModel.Comments, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
@@ -71,7 +71,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </Grid>
-            </ScrollView>
+            </ScrollViewer>
             <components:EmptyHolder
                 Description="{ext:Locale Name=NoReply}"
                 Emoji="&#x1FAE2;"

--- a/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentMainPanel.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Comment/CommentMainPanel.xaml.cs
@@ -80,7 +80,7 @@ public sealed partial class CommentMainPanel : CommentMainPanelBase
         CheckCommentCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.xaml
@@ -65,9 +65,9 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:ExternalPlayer">
-                    <ScrollView
+                    <ScrollViewer
                         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                        Style="{StaticResource PageScrollViewStyle}"
+                        Style="{StaticResource PageScrollViewerStyle}"
                         VerticalScrollBarVisibility="Hidden">
                         <Grid Padding="12">
                             <TextBlock
@@ -83,7 +83,7 @@
                                 TextWrapping="Wrap"
                                 Visibility="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=ViewModel.LogMessage, Converter={StaticResource ObjectToVisibilityConverter}}" />
                         </Grid>
-                    </ScrollView>
+                    </ScrollViewer>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Desktop/BiliCopilot.UI/Controls/Favorites/PgcFavoriteBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Favorites/PgcFavoriteBody.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="SeasonScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="SeasonScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource PgcLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoFavoritesPgc}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Favorites/PgcFavoriteBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Favorites/PgcFavoriteBody.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class PgcFavoriteBody : PgcFavoriteControlBase
         CheckSeasonCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Favorites/UgcFavoriteBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Favorites/UgcFavoriteBody.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=SeasonHasNoVideos}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Favorites/UgcFavoriteBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Favorites/UgcFavoriteBody.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class UgcFavoriteBody : UgcFavoriteControlBase
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Favorites/VideoFavoriteBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Favorites/VideoFavoriteBody.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoFavoriteVideos}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Favorites/VideoFavoriteBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Favorites/VideoFavoriteBody.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class VideoFavoriteBody : VideoFavoriteControlBase
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/History/ArticleHistorySection.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/ArticleHistorySection.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="ArticleScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="ArticleScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoHistoryArticles}"

--- a/src/Desktop/BiliCopilot.UI/Controls/History/ArticleHistorySection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/ArticleHistorySection.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class ArticleHistorySection : ArticleHistorySectionBase
         CheckArticleCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/History/HistoryVideoSearchSection.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/HistoryVideoSearchSection.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.SearchVideos, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoSpecificData}"

--- a/src/Desktop/BiliCopilot.UI/Controls/History/HistoryVideoSearchSection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/HistoryVideoSearchSection.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class HistoryVideoSearchSection : HistoryPageControlBase
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/History/LiveHistorySection.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/LiveHistorySection.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="LiveScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="LiveScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoHistoryLives}"

--- a/src/Desktop/BiliCopilot.UI/Controls/History/LiveHistorySection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/LiveHistorySection.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class LiveHistorySection : LiveHistorySectionBase
         CheckLiveCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/History/VideoHistorySection.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/VideoHistorySection.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoHistoryVideos}"

--- a/src/Desktop/BiliCopilot.UI/Controls/History/VideoHistorySection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/History/VideoHistorySection.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class VideoHistorySection : VideoHistorySectionBase
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveRecommendMainBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveRecommendMainBody.xaml
@@ -11,7 +11,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="LiveScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="LiveScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.RecommendRooms, Mode=OneWay}" Layout="{StaticResource LiveLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -21,7 +21,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
         <components:LoadingWidget Visibility="{x:Bind ViewModel.IsRecommendLoading, Mode=OneWay}" />
     </Grid>
 </local:LivePartitionPageControlBase>

--- a/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveRecommendMainBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveRecommendMainBody.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class LiveRecommendMainBody : LivePartitionPageControlBase
         CheckLiveCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveSubPartitionMainBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveSubPartitionMainBody.xaml
@@ -15,11 +15,11 @@
             <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        
-        <ScrollView
+
+        <ScrollViewer
             x:Name="LiveScrollView"
             Grid.Row="1"
-            Style="{StaticResource PageScrollViewStyle}">
+            Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Rooms, Mode=OneWay}">
                     <ItemsRepeater.ItemTemplate>
@@ -37,7 +37,7 @@
                     </ItemsRepeater.Layout>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
         <components:LoadingWidget Grid.Row="1" Visibility="{x:Bind ViewModel.IsLiveLoading, Mode=OneWay}" />
     </Grid>
 </local:LiveSubPartitionControlBase>

--- a/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveSubPartitionMainBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/LivePartition/LiveSubPartitionMainBody.xaml.cs
@@ -71,7 +71,7 @@ public sealed partial class LiveSubPartitionMainBody : LiveSubPartitionControlBa
         CheckRoomCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Message/ChatSessionBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Message/ChatSessionBody.xaml
@@ -16,7 +16,7 @@
             <RowDefinition />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <ScrollView x:Name="MessageView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="MessageView" Style="{StaticResource PageScrollViewerStyle}">
             <ItemsControl
                 MaxWidth="800"
                 Margin="20,12,20,20"
@@ -32,7 +32,7 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-        </ScrollView>
+        </ScrollViewer>
         <components:EmptyHolder
             Description="{ext:Locale Name=NoMessage}"
             Emoji="&#x1F37B;"

--- a/src/Desktop/BiliCopilot.UI/Controls/Message/ChatSessionBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Message/ChatSessionBody.xaml.cs
@@ -67,7 +67,7 @@ public sealed partial class ChatSessionBody : ChatMessageControlBase
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {
-            MessageView.ScrollTo(0, MessageView.ExtentHeight + MessageView.ViewportHeight + 100, new ScrollingScrollOptions(ScrollingAnimationMode.Disabled));
+            MessageView.ChangeView(0, MessageView.ExtentHeight + MessageView.ViewportHeight + 100, default, true);
         });
     }
 }

--- a/src/Desktop/BiliCopilot.UI/Controls/Message/NotifyMessageBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Message/NotifyMessageBody.xaml
@@ -14,7 +14,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="MessageScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="MessageScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater MaxWidth="1000" ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}">
                     <ItemsRepeater.ItemTemplate>
@@ -27,7 +27,7 @@
                     </ItemsRepeater.Layout>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoMessage}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Message/NotifyMessageBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Message/NotifyMessageBody.xaml.cs
@@ -65,7 +65,7 @@ public sealed partial class NotifyMessageBody : NotifyMessageControlBase
 
         _viewModel = ViewModel;
         _viewModel.ListUpdated += OnMessageListUpdatedAsync;
-        MessageScrollView.ScrollTo(0, 0);
+        MessageScrollView.ChangeView(0, 0, default);
     }
 
     private async void OnMessageListUpdatedAsync(object? sender, EventArgs e)
@@ -74,7 +74,7 @@ public sealed partial class NotifyMessageBody : NotifyMessageControlBase
         CheckMessageCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMainBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMainBody.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="MomentScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="MomentScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsControl MaxWidth="1200" ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}">
                     <ItemsControl.ItemTemplate>
@@ -25,7 +25,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoSpecificData}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMainBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMainBody.xaml.cs
@@ -75,7 +75,7 @@ public sealed partial class ComprehensiveMainBody : MomentUperSectionControlBase
         CheckMomentCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMomentSpaceControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMomentSpaceControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="MomentScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="MomentScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsControl MaxWidth="1200" ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}">
                     <ItemsControl.ItemTemplate>
@@ -25,7 +25,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoSpecificData}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMomentSpaceControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/ComprehensiveMomentSpaceControl.xaml.cs
@@ -45,7 +45,7 @@ public sealed partial class ComprehensiveMomentSpaceControl : UserMomentDetailCo
         CheckMomentCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/UserSpaceVideoSearchSection.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/UserSpaceVideoSearchSection.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.SearchVideos, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoSpecificData}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/UserSpaceVideoSearchSection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/UserSpaceVideoSearchSection.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class UserSpaceVideoSearchSection : UserSpacePageControlBa
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSectionDetailControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSectionDetailControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource MomentLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoSpecificData}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSectionDetailControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSectionDetailControl.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class VideoMomentSectionDetailControl : VideoMomentSection
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSpaceControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSpaceControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource MomentLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoSpecificData}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSpaceControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Moment/VideoMomentSpaceControl.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class VideoMomentSpaceControl : UserMomentDetailControlBas
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Pgc/AnimeTimelineMainControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Pgc/AnimeTimelineMainControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="SeasonScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="SeasonScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.SelectedTimeline.Items, Mode=OneWay}" Layout="{StaticResource PgcLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=TimelineHasNoVideo}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Pgc/EntertainmentIndexMainControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Pgc/EntertainmentIndexMainControl.xaml
@@ -11,7 +11,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="SeasonScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="SeasonScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource PgcLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -21,7 +21,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
         <components:LoadingWidget Visibility="{x:Bind ViewModel.IsSeasonLoading, Mode=OneWay}" />
     </Grid>
 </local:EntertainmentIndexControlBase>

--- a/src/Desktop/BiliCopilot.UI/Controls/Pgc/EntertainmentIndexMainControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Pgc/EntertainmentIndexMainControl.xaml.cs
@@ -65,7 +65,7 @@ public sealed partial class EntertainmentIndexMainControl : EntertainmentIndexCo
         }
 
         _viewModel = ViewModel;
-        SeasonScrollView.ScrollTo(0, 0, new ScrollingScrollOptions(ScrollingAnimationMode.Disabled));
+        SeasonScrollView.ChangeView(0, 0, default, true);
         _viewModel.ItemsUpdated += OnItemsUpdatedAsync;
     }
 
@@ -75,7 +75,7 @@ public sealed partial class EntertainmentIndexMainControl : EntertainmentIndexCo
         CheckSeasonCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Pgc/EntertainmentIndexSideControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Pgc/EntertainmentIndexSideControl.xaml.cs
@@ -10,8 +10,5 @@ public sealed partial class EntertainmentIndexSideControl : EntertainmentIndexCo
     /// <summary>
     /// Initializes a new instance of the <see cref="EntertainmentIndexSideControl"/> class.
     /// </summary>
-    public EntertainmentIndexSideControl()
-    {
-        InitializeComponent();
-    }
+    public EntertainmentIndexSideControl() => InitializeComponent();
 }

--- a/src/Desktop/BiliCopilot.UI/Controls/Popular/PopularMainBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Popular/PopularMainBody.xaml
@@ -29,7 +29,7 @@
     </UserControl.Resources>
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Videos}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -42,7 +42,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
         <components:LoadingWidget Visibility="{x:Bind ViewModel.IsVideoLoading, Mode=OneWay}" />
     </Grid>
 </local:PopularPageControlBase>

--- a/src/Desktop/BiliCopilot.UI/Controls/Popular/PopularMainBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Popular/PopularMainBody.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class PopularMainBody : PopularPageControlBase
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/ArticleSectionDetailControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/ArticleSectionDetailControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="ArticleScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="ArticleScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource ArticleLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoArticles}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/ArticleSectionDetailControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/ArticleSectionDetailControl.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class ArticleSectionDetailControl : ArticleSectionDetailCo
         CheckArticleCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/LiveSectionDetailControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/LiveSectionDetailControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="LiveScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="LiveScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource LiveLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoLiveRooms}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/LiveSectionDetailControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/LiveSectionDetailControl.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class LiveSectionDetailControl : LiveSectionDetailControlB
         CheckLiveCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/PgcSectionDetailControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/PgcSectionDetailControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="PgcScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="PgcScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource PgcLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoPgcSeasons}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/PgcSectionDetailControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/PgcSectionDetailControl.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class PgcSectionDetailControl : PgcSectionDetailControlBas
         CheckPgcCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/UserSectionDetailControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/UserSectionDetailControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="UserScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="UserScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource UserLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoUsers}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/UserSectionDetailControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/UserSectionDetailControl.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class UserSectionDetailControl : UserSectionDetailControlB
         CheckUserCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/VideoSectionDetailControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/VideoSectionDetailControl.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoSpecificData}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/VideoSectionDetailControl.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/VideoSectionDetailControl.xaml.cs
@@ -42,7 +42,7 @@ public sealed partial class VideoSectionDetailControl : VideoSectionDetailContro
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Users/FansBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Users/FansBody.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="UserScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="UserScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Users}" Layout="{StaticResource UserLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoFans}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Users/FansBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Users/FansBody.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class FansBody : FansPageControlBase
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/Users/FollowsMainBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Users/FollowsMainBody.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="UserScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="UserScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Users}" Layout="{StaticResource UserLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoFollows}"

--- a/src/Desktop/BiliCopilot.UI/Controls/Users/FollowsMainBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Users/FollowsMainBody.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class FollowsMainBody : FollowsPageControlBase
         CheckUserCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/VideoPartition/VideoPartitionMainBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/VideoPartition/VideoPartitionMainBody.xaml
@@ -11,10 +11,10 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView
+        <ScrollViewer
             x:Name="VideoScrollView"
             Grid.Row="1"
-            Style="{StaticResource PageScrollViewStyle}">
+            Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Videos, Mode=OneWay}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -24,7 +24,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
         <components:LoadingWidget Grid.Row="1" Visibility="{x:Bind ViewModel.IsVideoLoading, Mode=OneWay}" />
     </Grid>
 </local:VideoPartitionDetailControlBase>

--- a/src/Desktop/BiliCopilot.UI/Controls/VideoPartition/VideoPartitionMainBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/VideoPartition/VideoPartitionMainBody.xaml.cs
@@ -73,7 +73,7 @@ public sealed partial class VideoPartitionMainBody : VideoPartitionDetailControl
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/ViewLater/ViewLaterBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/ViewLater/ViewLaterBody.xaml
@@ -12,7 +12,7 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollView x:Name="VideoScrollView" Style="{StaticResource PageScrollViewStyle}">
+        <ScrollViewer x:Name="VideoScrollView" Style="{StaticResource PageScrollViewerStyle}">
             <Grid Margin="16,12">
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Videos}" Layout="{StaticResource VideoLayout}">
                     <ItemsRepeater.ItemTemplate>
@@ -22,7 +22,7 @@
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>
             </Grid>
-        </ScrollView>
+        </ScrollViewer>
 
         <components:EmptyHolder
             Description="{ext:Locale Name=NoViewLaterVideos}"

--- a/src/Desktop/BiliCopilot.UI/Controls/ViewLater/ViewLaterBody.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/ViewLater/ViewLaterBody.xaml.cs
@@ -41,7 +41,7 @@ public sealed partial class ViewLaterBody : ViewLaterPageControlBase
         CheckVideoCount();
     }
 
-    private void OnViewChanged(ScrollView sender, object args)
+    private void OnViewChanged(object? sender, ScrollViewerViewChangedEventArgs args)
     {
         DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
         {

--- a/src/Desktop/BiliCopilot.UI/Controls/WebDav/WebDavPageBody.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/WebDav/WebDavPageBody.xaml
@@ -13,7 +13,7 @@
 
     <Grid>
         <Grid Visibility="{x:Bind ViewModel.IsInvalidConfig, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
-            <ScrollView Style="{StaticResource PageScrollViewStyle}">
+            <ScrollViewer Style="{StaticResource PageScrollViewerStyle}">
                 <ItemsControl Margin="16,12" ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="items:WebDavStorageItemViewModel">
@@ -21,7 +21,7 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-            </ScrollView>
+            </ScrollViewer>
             <components:EmptyHolder
                 Title="{ext:Locale Name=NoFiles}"
                 Description="{ext:Locale Name=NoFilesDescription}"

--- a/src/Desktop/BiliCopilot.UI/Pages/Overlay/LivePlayerPage.xaml
+++ b/src/Desktop/BiliCopilot.UI/Pages/Overlay/LivePlayerPage.xaml
@@ -57,11 +57,11 @@
                     Grid.Row="2"
                     Grid.Column="1" />
 
-                <ScrollView
+                <ScrollViewer
                     x:Name="VideoContainer"
                     Grid.Row="2"
                     Margin="0,0,-6,0"
-                    Style="{StaticResource PageScrollViewStyle}">
+                    Style="{StaticResource PageScrollViewerStyle}">
                     <StackPanel>
                         <StackPanel.ChildrenTransitions>
                             <RepositionThemeTransition IsStaggeringEnabled="False" />
@@ -120,7 +120,7 @@
                             <player:LiveDescriptorControl VerticalAlignment="Top" ViewModel="{x:Bind ViewModel, Mode=OneWay}" />
                         </Grid>
                     </StackPanel>
-                </ScrollView>
+                </ScrollViewer>
 
                 <Grid
                     x:Name="SideHeader"

--- a/src/Desktop/BiliCopilot.UI/Pages/Overlay/PgcPlayerPage.xaml
+++ b/src/Desktop/BiliCopilot.UI/Pages/Overlay/PgcPlayerPage.xaml
@@ -57,11 +57,11 @@
                     Grid.Row="2"
                     Grid.Column="1" />
 
-                <ScrollView
+                <ScrollViewer
                     x:Name="VideoContainer"
                     Grid.Row="2"
                     Margin="0,0,-6,0"
-                    Style="{StaticResource PageScrollViewStyle}">
+                    Style="{StaticResource PageScrollViewerStyle}">
                     <StackPanel>
                         <StackPanel.ChildrenTransitions>
                             <RepositionThemeTransition IsStaggeringEnabled="False" />
@@ -136,7 +136,7 @@
                                 ViewModel="{x:Bind ViewModel, Mode=OneWay}" />
                         </Grid>
                     </StackPanel>
-                </ScrollView>
+                </ScrollViewer>
 
                 <Grid
                     x:Name="SideHeader"

--- a/src/Desktop/BiliCopilot.UI/Pages/Overlay/VideoPlayerPage.xaml
+++ b/src/Desktop/BiliCopilot.UI/Pages/Overlay/VideoPlayerPage.xaml
@@ -59,11 +59,11 @@
                     Grid.Row="2"
                     Grid.Column="1" />
 
-                <ScrollView
+                <ScrollViewer
                     x:Name="VideoContainer"
                     Grid.Row="2"
                     Margin="0,0,-6,0"
-                    Style="{StaticResource PageScrollViewStyle}">
+                    Style="{StaticResource PageScrollViewerStyle}">
                     <StackPanel>
                         <StackPanel.ChildrenTransitions>
                             <RepositionThemeTransition IsStaggeringEnabled="False" />
@@ -135,7 +135,7 @@
                             <player:VideoOperationControl Grid.Column="1" ViewModel="{x:Bind ViewModel, Mode=OneWay}" />
                         </Grid>
                     </StackPanel>
-                </ScrollView>
+                </ScrollViewer>
 
                 <InfoBar
                     Grid.Row="2"

--- a/src/Desktop/BiliCopilot.UI/Pages/SettingsPage.xaml
+++ b/src/Desktop/BiliCopilot.UI/Pages/SettingsPage.xaml
@@ -36,11 +36,11 @@
             Height="1"
             HorizontalAlignment="Stretch"
             Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
-        <ScrollView
+        <ScrollViewer
             x:Name="GenericContainer"
             Grid.Row="2"
             Padding="16,0"
-            Style="{StaticResource PageScrollViewStyle}">
+            Style="{StaticResource PageScrollViewerStyle}">
             <StackPanel Margin="0,12" Spacing="4">
                 <StackPanel.ChildrenTransitions>
                     <RepositionThemeTransition IsStaggeringEnabled="False" />
@@ -99,12 +99,12 @@
                         NavigateUri="https://github.com/Richasy/Bili.Copilot/issues/new/choose" />
                 </StackPanel>
             </StackPanel>
-        </ScrollView>
-        <ScrollView
+        </ScrollViewer>
+        <ScrollViewer
             x:Name="AIContainer"
             Grid.Row="2"
             Padding="16,0"
-            Style="{StaticResource PageScrollViewStyle}"
+            Style="{StaticResource PageScrollViewerStyle}"
             Visibility="Collapsed">
             <StackPanel
                 x:Name="AIPanel"
@@ -114,6 +114,6 @@
                     <RepositionThemeTransition IsStaggeringEnabled="False" />
                 </StackPanel.ChildrenTransitions>
             </StackPanel>
-        </ScrollView>
+        </ScrollViewer>
     </Grid>
 </local:SettingsPageBase>

--- a/src/Desktop/BiliCopilot.UI/Styles/Overrides.xaml
+++ b/src/Desktop/BiliCopilot.UI/Styles/Overrides.xaml
@@ -8,7 +8,6 @@
     <Style x:Key="PageScrollViewerStyle" TargetType="ScrollViewer">
         <Setter Property="HorizontalScrollMode" Value="Disabled" />
         <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
-        <Setter Property="Padding" Value="20,0" />
     </Style>
 
     <Style x:Key="PageScrollViewStyle" TargetType="ScrollView">


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #481 

没有找到合适的方法加快 ScrollView 的滚动速率，目前先将主体可滚动内容暂时切换回 ScrollViewer。

本地测试没有发现 layout cycled 问题，发布后等待反馈

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->
