### PR TITLE
修复快速退出播放界面时的内存访问异常

### DIFF
--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/ExternalPlayerViewModel/ExternalPlayerViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/ExternalPlayerViewModel/ExternalPlayerViewModel.cs
@@ -27,8 +27,8 @@ public sealed partial class ExternalPlayerViewModel : PlayerViewModelBase
 
     private void ResetPlayer()
     {
-        _mpvDebugMessages.Clear();
-        _dispatcherQueue.TryEnqueue(() =>
+        _mpvDebugMessages?.Clear();
+        _dispatcherQueue?.TryEnqueue(() =>
         {
             LogMessage = string.Empty;
         });

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/MpvPlayerViewModel/MpvPlayerViewModel.Overrides.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/MpvPlayerViewModel/MpvPlayerViewModel.Overrides.cs
@@ -70,7 +70,7 @@ public sealed partial class MpvPlayerViewModel
 
         try
         {
-            if (!string.IsNullOrEmpty(_videoUrl))
+            if (!string.IsNullOrEmpty(_videoUrl) && !Player.IsDisposed)
             {
                 await Player.Client.ExecuteAsync(["loadfile", _videoUrl, "replace"]);
 
@@ -79,7 +79,7 @@ public sealed partial class MpvPlayerViewModel
                     await WaitUntilAddAudioAsync(_audioUrl);
                 }
             }
-            else if (!string.IsNullOrEmpty(_audioUrl))
+            else if (!string.IsNullOrEmpty(_audioUrl) && !Player.IsDisposed)
             {
                 await Player.Client.ExecuteAsync(["loadfile", _audioUrl, "replace"]);
             }

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/MpvPlayerViewModel/MpvPlayerViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/MpvPlayerViewModel/MpvPlayerViewModel.cs
@@ -160,6 +160,11 @@ public sealed partial class MpvPlayerViewModel : PlayerViewModelBase
 
             try
             {
+                if (Player.IsDisposed)
+                {
+                    return;
+                }
+
                 await Player.Client.ExecuteAsync(["audio-add", audioUrl]);
                 isAudioAdded = true;
             }

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Events.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Events.cs
@@ -37,8 +37,14 @@ public abstract partial class PlayerViewModelBase
     /// </summary>
     protected virtual void UpdateState(PlayerState state)
     {
-        _dispatcherQueue.TryEnqueue(() =>
+        _dispatcherQueue.TryEnqueue(async () =>
         {
+            if (_isClosed)
+            {
+                await OnCloseAsync();
+                return;
+            }
+
             if (state == PlayerState.Playing)
             {
                 IsPaused = false;

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Methods.cs
@@ -17,7 +17,7 @@ public abstract partial class PlayerViewModelBase
     /// <returns><see cref="Task"/>.</returns>
     protected async Task TryLoadPlayDataAsync()
     {
-        if (string.IsNullOrEmpty(_videoUrl) && string.IsNullOrEmpty(_audioUrl))
+        if ((string.IsNullOrEmpty(_videoUrl) && string.IsNullOrEmpty(_audioUrl)) || _isClosed)
         {
             return;
         }
@@ -76,6 +76,11 @@ public abstract partial class PlayerViewModelBase
                 ? $"--cookies --no-ytdl --http-header-fields=\\\"Cookie:{this.Get<IBiliCookiesResolver>().GetCookieString()}\\\" --http-header-fields=\\\"Referer:{LiveReferer}\\\" --user-agent \\\"{LiveUserAgent}\\\""
                 : $"--cookies --http-header-fields=\\\"Cookie:{this.Get<IBiliCookiesResolver>().GetCookieString()}\\\" --http-header-fields=\\\"Referer:{VideoReferer}\\\" --user-agent=\\\"{VideoUserAgent}\\\"";
         var exeName = isMpv ? "mpv" : "mpvnet";
+        if (!string.IsNullOrEmpty(_extraOptions))
+        {
+            httpParams += $" --script-opts=\\\"cid={_extraOptions}\\\"";
+        }
+
         var command = $"{exeName} {httpParams} --title=\\\"{Title}\\\" \\\"{_videoUrl}\\\"";
         if (!string.IsNullOrEmpty(_audioUrl))
         {

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Properties.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Properties.cs
@@ -59,6 +59,7 @@ public abstract partial class PlayerViewModelBase
     protected SystemMediaTransportControls? _smtc;
 
     protected bool _isInitialized;
+    protected bool _isClosed;
 
     [ObservableProperty]
     private bool _isPlayerInitializing;

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
@@ -66,6 +66,7 @@ public abstract partial class PlayerViewModelBase : ViewModelBase
     /// <returns><see cref="Task"/>.</returns>
     public virtual async Task SetPlayDataAsync(string? videoUrl, string? audioUrl, bool isAutoPlay, int position = 0, string? contentType = default, string? extraOptions = default)
     {
+        _isClosed = false;
         if (_smtc is null)
         {
             var currentWindow = this.Get<AppViewModel>().ActivatedWindow.GetWindowHandle();
@@ -120,7 +121,7 @@ public abstract partial class PlayerViewModelBase : ViewModelBase
         MaxSpeed = isSpeedEnhancement ? 6.0 : 3.0;
         SpeedStep = isSpeedEnhancement ? 0.1 : 0.5;
 
-        if (_isInitialized)
+        if (_isInitialized && !_isClosed)
         {
             BeforeLoadPlayData();
             await TryLoadPlayDataAsync();
@@ -176,6 +177,7 @@ public abstract partial class PlayerViewModelBase : ViewModelBase
     public Task CloseAsync()
     {
         IsPaused = true;
+        _isClosed = true;
         if (_smtc is not null)
         {
             _smtc.DisplayUpdater.ClearAll();

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
@@ -70,6 +70,11 @@ public sealed partial class VideoPlayerPageViewModel
             }
         }
 
+        if (_view == default)
+        {
+            return;
+        }
+
         var preferFormatSetting = SettingsToolkit.ReadLocalSetting(SettingNames.PreferQuality, PreferQualityType.Auto);
         var availableFormats = Formats.Where(p => p.IsEnabled).ToList();
         var partIndex = _view.Parts?.IndexOf(_part) ?? 0;

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Operations.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Operations.cs
@@ -303,6 +303,11 @@ public sealed partial class VideoPlayerPageViewModel
 
     private void PlayerStateChanged(PlayerState state)
     {
+        if (_view == null)
+        {
+            return;
+        }
+
         if (state == PlayerState.Playing)
         {
             if (Danmaku.IsEmpty())

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
@@ -138,6 +138,11 @@ public sealed partial class VideoPlayerPageViewModel : PlayerPageViewModelBase
         {
             _dashLoadCancellationTokenSource = new CancellationTokenSource();
             var info = await _service.GetVideoPlayDetailAsync(_view.Information.Identifier, Convert.ToInt64(part.Identifier.Id), _dashLoadCancellationTokenSource.Token);
+            if (_view is null)
+            {
+                return;
+            }
+
             InitializeDash(info);
             var onlineCount = await _service.GetOnlineViewerAsync(_view.Information.Identifier.Id, part.Identifier.Id, _dashLoadCancellationTokenSource.Token);
             OnlineCountText = onlineCount.Text;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #558 

造成崩溃的主要原因：

1. 重复释放MPV播放器对象
2. 访问已释放对象的属性或方法

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
