### PR TITLE
优化播放控制器触发逻辑

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.cs
@@ -19,8 +19,10 @@ public sealed partial class BiliPlayer : PlayerControlBase
 
     private double _lastSpeed;
     private double _cursorStayTime;
+    private double _mtcStayTime;
     private bool _isCursorDisposed;
     private bool _isTouch;
+    private Point? _lastPointerPoint;
 
     private double _manipulationDeltaX = 0d;
     private double _manipulationDeltaY = 0d;
@@ -126,10 +128,6 @@ public sealed partial class BiliPlayer : PlayerControlBase
         => HandlePointerEvent(e, true);
 
     /// <inheritdoc/>
-    protected override void OnPointerCaptureLost(PointerRoutedEventArgs e)
-        => HandlePointerEvent(e, true);
-
-    /// <inheritdoc/>
     protected override void OnViewModelChanged(PlayerViewModelBase? oldValue, PlayerViewModelBase? newValue)
     {
         if (newValue is null)
@@ -160,10 +158,13 @@ public sealed partial class BiliPlayer : PlayerControlBase
         {
             if (forceHideTransportControls)
             {
+                _lastPointerPoint = default;
+                _mtcStayTime = 0;
                 SetTransportVisibility(false);
                 return;
             }
 
+            _mtcStayTime = 0;
             CheckTransportControlVisibility(e);
         }
     }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

1. 播放区域内移动鼠标就会显示播放控制器
2. 将光标移入播放控制器范围内，控制器不会消失
3. 光标移出播放控制器区域后，播放控制器不会立刻消失，而是等待2秒后再消失
4. 去除对 PointerCaptureLost 的监听，对其监听后的处理会导致点击弹幕输入框时播放控制器消失

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
