### PR TITLE
修复退出播放独占后，直播消息列表没有滚动到底部的问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/ViewModels/Components/LiveChatSectionDetailViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Components/LiveChatSectionDetailViewModel.cs
@@ -118,6 +118,10 @@ public sealed partial class LiveChatSectionDetailViewModel : ViewModelBase
         IsSending = false;
     }
 
+    [RelayCommand]
+    private void ScrollToBottom()
+        => ScrollToBottomRequested?.Invoke(this, EventArgs.Empty);
+
     private void MessageLoop()
     {
         _ = Task.Run(async () =>

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Commands.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Commands.cs
@@ -140,6 +140,8 @@ public abstract partial class PlayerViewModelBase
         {
             this.Get<AppViewModel>().MakeCurrentWindowExitFullScreenCommand.Execute(default);
         }
+
+        _windowStateChangeAction?.Invoke();
     }
 
     [RelayCommand]
@@ -154,6 +156,8 @@ public abstract partial class PlayerViewModelBase
         {
             this.Get<AppViewModel>().MakeCurrentWindowExitOverlapCommand.Execute(default);
         }
+
+        _windowStateChangeAction?.Invoke();
     }
 
     [RelayCommand]
@@ -168,6 +172,8 @@ public abstract partial class PlayerViewModelBase
         {
             this.Get<AppViewModel>().MakeCurrentWindowExitCompactOverlayCommand.Execute(default);
         }
+
+        _windowStateChangeAction?.Invoke();
     }
 
     [RelayCommand]

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Properties.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Properties.cs
@@ -54,6 +54,7 @@ public abstract partial class PlayerViewModelBase
     protected Action _endAction;
     protected Action _reloadAction;
     protected Action _tapToggleFullScreenAction;
+    protected Action _windowStateChangeAction;
     protected DisplayRequest _displayRequest;
 
     protected SystemMediaTransportControls? _smtc;

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
@@ -131,6 +131,12 @@ public abstract partial class PlayerViewModelBase : ViewModelBase
         => _progressAction = action;
 
     /// <summary>
+    /// 注入窗口状态改变时的回调.
+    /// </summary>
+    public void SetWindowStateChangeAction(Action action)
+        => _windowStateChangeAction = action;
+
+    /// <summary>
     /// 注入状态改变时的回调.
     /// </summary>
     public void SetStateAction(Action<PlayerState> action)

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/LivePlayerPageViewModel/LivePlayerPageViewModel.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/LivePlayerPageViewModel/LivePlayerPageViewModel.Methods.cs
@@ -82,4 +82,7 @@ public sealed partial class LivePlayerPageViewModel
 
         ChangeFormatCommand.Execute(SelectedFormat);
     }
+
+    private void ScrollMessagesToBottom()
+        => Chat.ScrollToBottomCommand.Execute(default);
 }

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/LivePlayerPageViewModel/LivePlayerPageViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/LivePlayerPageViewModel/LivePlayerPageViewModel.cs
@@ -40,6 +40,7 @@ public sealed partial class LivePlayerPageViewModel : PlayerPageViewModelBase
         Player.IsLive = true;
         Player.SetProgressAction(PlayerProgressChanged);
         Player.SetReloadAction(ReloadFormat);
+        Player.SetWindowStateChangeAction(ScrollMessagesToBottom);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #634 

窗口状态改变时触发滚动到底部的命令

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新