### PR TITLE
修复点击播放列表内的视频依然会在新窗口播放的问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Player/VideoPlaylistSection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Player/VideoPlaylistSection.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using BiliCopilot.UI.Models;
 using BiliCopilot.UI.ViewModels.Components;
 using BiliCopilot.UI.ViewModels.Items;
 using Richasy.WinUI.Share.Base;
@@ -29,7 +30,7 @@ public sealed partial class VideoPlaylistSection : VideoPlaylistSectionBase
         var item = sender.SelectedItem as VideoItemViewModel;
         if (item is not null && ViewModel.SelectedItem != item)
         {
-            item.PlayCommand.Execute(default);
+            ViewModel.Page.InitializePageCommand.Execute(new VideoSnapshot(item.Data));
         }
     }
 

--- a/src/Desktop/BiliCopilot.UI/Controls/Player/VideoSeasonSection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Player/VideoSeasonSection.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using BiliCopilot.UI.Models;
 using BiliCopilot.UI.ViewModels.Components;
 using BiliCopilot.UI.ViewModels.Items;
 using Richasy.BiliKernel.Models.Media;
@@ -37,7 +38,7 @@ public sealed partial class VideoSeasonSection : VideoSeasonSectionBase
         var item = sender.SelectedItem as VideoItemViewModel;
         if (item is not null && ViewModel.SelectedItem != item)
         {
-            item.PlayCommand.Execute(default);
+            ViewModel.Page.InitializePageCommand.Execute(new VideoSnapshot(item.Data));
         }
     }
 

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoPlayerPlaylistSectionDetailViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoPlayerPlaylistSectionDetailViewModel.cs
@@ -3,6 +3,7 @@
 using BiliCopilot.UI.Models.Constants;
 using BiliCopilot.UI.Toolkits;
 using BiliCopilot.UI.ViewModels.Items;
+using BiliCopilot.UI.ViewModels.View;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Richasy.BiliKernel.Models.Media;
@@ -27,6 +28,7 @@ public sealed partial class VideoPlayerPlaylistSectionDetailViewModel : ViewMode
     /// Initializes a new instance of the <see cref="VideoPlayerPlaylistSectionDetailViewModel"/> class.
     /// </summary>
     public VideoPlayerPlaylistSectionDetailViewModel(
+        VideoPlayerPageViewModel page,
         IList<VideoInformation> list,
         string videoId)
     {
@@ -37,6 +39,11 @@ public sealed partial class VideoPlayerPlaylistSectionDetailViewModel : ViewMode
 
     /// <inheritdoc/>
     public string Title => ResourceToolkit.GetLocalizedString(StringNames.Playlist);
+
+    /// <summary>
+    /// 页面视图模型.
+    /// </summary>
+    public VideoPlayerPageViewModel Page { get; }
 
     [RelayCommand]
     private static Task TryFirstLoadAsync()

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoPlayerSeasonSectionDetailViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoPlayerSeasonSectionDetailViewModel.cs
@@ -3,6 +3,7 @@
 using BiliCopilot.UI.Models.Constants;
 using BiliCopilot.UI.Toolkits;
 using BiliCopilot.UI.ViewModels.Items;
+using BiliCopilot.UI.ViewModels.View;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Richasy.BiliKernel.Models.Media;
@@ -36,9 +37,11 @@ public sealed partial class VideoPlayerSeasonSectionDetailViewModel : ViewModelB
     /// Initializes a new instance of the <see cref="VideoPlayerSeasonSectionDetailViewModel"/> class.
     /// </summary>
     public VideoPlayerSeasonSectionDetailViewModel(
+        VideoPlayerPageViewModel page,
         IList<VideoSeason> seasons,
         string videoId)
     {
+        Page = page;
         Seasons = seasons.ToList();
         _videoId = videoId;
         var selectedSeason = Seasons.FirstOrDefault(p => p.Videos.Any(q => q.Identifier.Id == _videoId));
@@ -47,6 +50,11 @@ public sealed partial class VideoPlayerSeasonSectionDetailViewModel : ViewModelB
 
     /// <inheritdoc/>
     public string Title => ResourceToolkit.GetLocalizedString(StringNames.UgcSeason);
+
+    /// <summary>
+    /// 页面视图模型.
+    /// </summary>
+    public VideoPlayerPageViewModel Page { get; }
 
     [RelayCommand]
     private static Task TryFirstLoadAsync()

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Methods.cs
@@ -102,14 +102,7 @@ public sealed partial class PgcPlayerPageViewModel
             sections.Add(new PgcPlayerSeasonSectionDetailViewModel(_view.Seasons, _view.Information.Identifier.Id));
         }
 
-        if (sections.Count == 0)
-        {
-            sections.Add(_comments);
-        }
-        else
-        {
-            sections.Insert(1, _comments);
-        }
+        sections.Add(_comments);
 
         Sections = sections;
         SelectSection(Sections.First());

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
@@ -125,7 +125,7 @@ public sealed partial class VideoPlayerPageViewModel
 
         if (_playlist is not null)
         {
-            sections.Insert(0, new VideoPlayerPlaylistSectionDetailViewModel(_playlist, AvId));
+            sections.Insert(0, new VideoPlayerPlaylistSectionDetailViewModel(this, _playlist, AvId));
         }
 
         if (_view.Parts?.Count > 1)
@@ -135,7 +135,7 @@ public sealed partial class VideoPlayerPageViewModel
 
         if (_view.Seasons is not null)
         {
-            sections.Add(new VideoPlayerSeasonSectionDetailViewModel(_view.Seasons, AvId));
+            sections.Add(new VideoPlayerSeasonSectionDetailViewModel(this, _view.Seasons, AvId));
         }
 
         if (_view.Recommends is not null)

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
@@ -123,9 +123,9 @@ public sealed partial class VideoPlayerPageViewModel
             new VideoPlayerInfoSectionDetailViewModel(this),
         };
 
-        if (_playlist is not null)
+        if (_view.Seasons is not null)
         {
-            sections.Insert(0, new VideoPlayerPlaylistSectionDetailViewModel(this, _playlist, AvId));
+            sections.Insert(0, new VideoPlayerSeasonSectionDetailViewModel(this, _view.Seasons, AvId));
         }
 
         if (_view.Parts?.Count > 1)
@@ -133,9 +133,9 @@ public sealed partial class VideoPlayerPageViewModel
             sections.Add(new VideoPlayerPartSectionDetailViewModel(_view.Parts, _part.Identifier.Id, ChangePart));
         }
 
-        if (_view.Seasons is not null)
+        if (_playlist is not null)
         {
-            sections.Add(new VideoPlayerSeasonSectionDetailViewModel(this, _view.Seasons, AvId));
+            sections.Insert(0, new VideoPlayerPlaylistSectionDetailViewModel(this, _playlist, AvId));
         }
 
         if (_view.Recommends is not null)
@@ -143,7 +143,7 @@ public sealed partial class VideoPlayerPageViewModel
             sections.Add(new VideoPlayerRecommendSectionDetailViewModel(_view.Recommends));
         }
 
-        sections.Insert(1, _comments);
+        sections.Add(_comments);
 
         Sections = sections;
         SelectSection(Sections.First());


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #679 

现在点击播放列表/视频合集内的视频会优先在当前播放页面内加载

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
