### PR TITLE
修复岛播放器在退出后没有触发窗口关闭的问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/IslandPlayer.Win32.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/IslandPlayer.Win32.cs
@@ -171,6 +171,11 @@ public class MpvPlayerOverlayWindow : IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
-        _desktopWindowXamlSource?.Dispose();
+        if (_desktopWindowXamlSource != null)
+        {
+            _desktopWindowXamlSource.Content = default;
+            _desktopWindowXamlSource?.SiteBridge?.Dispose();
+            _desktopWindowXamlSource?.Dispose();
+        }
     }
 }

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/IslandPlayerViewModel/IslandPlayerViewModel.Overrides.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/IslandPlayerViewModel/IslandPlayerViewModel.Overrides.cs
@@ -17,12 +17,11 @@ public sealed partial class IslandPlayerViewModel
     /// <inheritdoc/>
     protected override async Task OnCloseAsync()
     {
-        if (!IsMediaLoaded())
+        if (IsMediaLoaded())
         {
-            return;
+            Player?.Pause();
         }
 
-        Player?.Pause();
         await Player?.DisposeAsync();
         _playerWindow?.Dispose();
         _overlayWindow?.Dispose();

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/MpvPlayerViewModel/MpvPlayerViewModel.Overrides.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/MpvPlayerViewModel/MpvPlayerViewModel.Overrides.cs
@@ -17,12 +17,11 @@ public sealed partial class MpvPlayerViewModel
     /// <inheritdoc/>
     protected override async Task OnCloseAsync()
     {
-        if (!IsMediaLoaded())
+        if (IsMediaLoaded())
         {
-            return;
+            Player?.Pause();
         }
 
-        Player?.Pause();
         await Player?.DisposeAsync();
     }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #694 

在播放完成后，播放器状态重置，因原先代码错误的判断条件，导致没有触发关闭逻辑。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
