### PR TITLE
修复岛播放器初始化时的父窗口选择

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/IslandPlayer.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/IslandPlayer.cs
@@ -12,7 +12,7 @@ namespace BiliCopilot.UI.Controls.Core;
 /// </summary>
 public sealed partial class IslandPlayer : LayoutControlBase<IslandPlayerViewModel>
 {
-    private readonly Window _parentWindow;
+    private Window _parentWindow;
     private MpvPlayerWindow _playerWindow;
     private MpvPlayerOverlayWindow _overlayWindow;
     private double _scale;
@@ -27,7 +27,6 @@ public sealed partial class IslandPlayer : LayoutControlBase<IslandPlayerViewMod
     public IslandPlayer()
     {
         DefaultStyleKey = typeof(IslandPlayer);
-        _parentWindow = this.Get<AppViewModel>().ActivatedWindow;
     }
 
     /// <summary>
@@ -57,6 +56,7 @@ public sealed partial class IslandPlayer : LayoutControlBase<IslandPlayerViewMod
     /// <inheritdoc/>
     protected override async void OnControlLoaded()
     {
+        _parentWindow = ViewModel.AttachedWindow;
         InitializeLayoutPoints();
         if (_playerWindow is null)
         {

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Properties.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.Properties.cs
@@ -158,6 +158,11 @@ public abstract partial class PlayerViewModelBase
     /// 视频标题.
     /// </summary>
     public string Title { get; set; }
+
+    /// <summary>
+    /// 播放器关联的窗口.
+    /// </summary>
+    public Window AttachedWindow { get; set; }
 }
 #pragma warning restore SA1600 // Elements should be documented
 #pragma warning restore SA1401 // Fields should be private

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
@@ -173,6 +173,7 @@ public abstract partial class PlayerViewModelBase : ViewModelBase
     {
         IsPaused = true;
         _isClosed = true;
+        AttachedWindow = default;
         if (_smtc is not null)
         {
             _smtc.DisplayUpdater.ClearAll();

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/PlayerPageViewModelBase.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/PlayerPageViewModelBase.cs
@@ -31,5 +31,7 @@ public abstract partial class PlayerPageViewModelBase : LayoutPageViewModelBase
             PlayerType.Island => new IslandPlayerViewModel(),
             _ => new NativePlayerViewModel(),
         };
+
+        Player.AttachedWindow = this.Get<AppViewModel>().ActivatedWindow;
     }
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #706 

如果在新窗口播放且在视频加载前切换窗口焦点就可能出现这个问题。所以在创建视图模型时就锁定窗口以避免这个情况发生

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
