### PR TITLE
修复收藏夹/稍后再看的播放全部没有遵循播放行为偏好的问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Forms/PlayerWindow.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Forms/PlayerWindow.xaml.cs
@@ -64,6 +64,22 @@ public sealed partial class PlayerWindow : WindowBase, IPlayerHostWindow, ITipWi
     }
 
     /// <summary>
+    /// 打开视频.
+    /// </summary>
+    public void OpenVideo((List<VideoInformation> videos, VideoSnapshot snapshot) data)
+    {
+        Activate();
+        var preferPlayer = SettingsToolkit.ReadLocalSetting(SettingNames.PlayerType, PlayerType.Island);
+        if (preferPlayer == PlayerType.Web)
+        {
+            MainFrame.Navigate(typeof(WebPlayerPage), $"https://www.bilibili.com/video/av{data.snapshot.Video.Identifier.Id}");
+            return;
+        }
+
+        MainFrame.Navigate(typeof(VideoPlayerPage), data);
+    }
+
+    /// <summary>
     /// 打开PGC内容.
     /// </summary>
     public void OpenPgc(MediaIdentifier pgc)

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoFavoriteSectionDetailViewModel/VideoFavoriteSectionDetailViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Components/VideoFavoriteSectionDetailViewModel/VideoFavoriteSectionDetailViewModel.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using BiliCopilot.UI.Forms;
 using BiliCopilot.UI.Models;
+using BiliCopilot.UI.Models.Constants;
 using BiliCopilot.UI.Pages.Overlay;
+using BiliCopilot.UI.Toolkits;
 using BiliCopilot.UI.ViewModels.Core;
 using BiliCopilot.UI.ViewModels.Items;
 using CommunityToolkit.Mvvm.Input;
@@ -102,14 +105,28 @@ public sealed partial class VideoFavoriteSectionDetailViewModel : ViewModelBase<
     [RelayCommand]
     private void PlayCurrentList()
     {
+        var preferDisplayMode = SettingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
+
         if (Items.Count == 1)
         {
             var video = Items.First();
+            if (preferDisplayMode == PlayerDisplayMode.NewWindow)
+            {
+                new PlayerWindow().OpenVideo(new VideoSnapshot(video.Data));
+                return;
+            }
+
             this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage), new VideoSnapshot(video.Data));
         }
         else
         {
             var data = (Items.Select(p => p.Data).ToList(), new VideoSnapshot(Items.First().Data));
+            if (preferDisplayMode == PlayerDisplayMode.NewWindow)
+            {
+                new PlayerWindow().OpenVideo(data);
+                return;
+            }
+
             this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage), data);
         }
     }

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/ViewLaterPageViewModel/ViewLaterPageViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/ViewLaterPageViewModel/ViewLaterPageViewModel.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Bili Copilot. All rights reserved.
 
+using BiliCopilot.UI.Forms;
 using BiliCopilot.UI.Models;
+using BiliCopilot.UI.Models.Constants;
 using BiliCopilot.UI.Pages.Overlay;
+using BiliCopilot.UI.Toolkits;
 using BiliCopilot.UI.ViewModels.Core;
 using BiliCopilot.UI.ViewModels.Items;
 using CommunityToolkit.Mvvm.Input;
@@ -110,13 +113,27 @@ public sealed partial class ViewLaterPageViewModel : ViewModelBase
     [RelayCommand]
     private void PlayAll()
     {
+        var preferDisplayMode = SettingsToolkit.ReadLocalSetting(SettingNames.DefaultPlayerDisplayMode, PlayerDisplayMode.Default);
         if (Videos.Count == 1)
         {
-            this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage), new VideoSnapshot(Videos.First().Data));
+            var video = Videos.First();
+            if (preferDisplayMode == PlayerDisplayMode.NewWindow)
+            {
+                new PlayerWindow().OpenVideo(new VideoSnapshot(video.Data));
+                return;
+            }
+
+            this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage), new VideoSnapshot(video.Data));
         }
         else
         {
             var data = (Videos.Select(p => p.Data).ToList(), new VideoSnapshot(Videos.First().Data));
+            if (preferDisplayMode == PlayerDisplayMode.NewWindow)
+            {
+                new PlayerWindow().OpenVideo(data);
+                return;
+            }
+
             this.Get<NavigationViewModel>().NavigateToOver(typeof(VideoPlayerPage), data);
         }
     }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

如果默认播放模式是新窗口，则点击播放全部应当遵循这一设置

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
