### PR TITLE
载入视频时完全加载弹幕库

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Danmaku/VideoDanmakuPanel.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Danmaku/VideoDanmakuPanel.xaml.cs
@@ -114,9 +114,13 @@ public sealed partial class VideoDanmakuPanel : DanmakuControlBase
 
     private void OnRequestClearDanmaku(object? sender, EventArgs e)
     {
-        _cachedDanmakus.Clear();
+        if (ViewModel.IsShowDanmaku)
+        {
+            _cachedDanmakus.Clear();
+            _lastProgress = 0;
+        }
+
         _danmakuController?.Clear();
-        _lastProgress = 0;
     }
 
     private void OnRequestAddSingleDanmaku(object? sender, string e)
@@ -192,8 +196,15 @@ public sealed partial class VideoDanmakuPanel : DanmakuControlBase
 
         DispatcherQueue?.TryEnqueue(() =>
         {
-            _danmakuController?.Close();
-            _danmakuController = new DanmakuFrostMaster(RootGrid, this.Get<ILogger<DanmakuFrostMaster>>());
+            if (_danmakuController is not null)
+            {
+                _danmakuController?.Clear();
+            }
+            else
+            {
+                _danmakuController = new DanmakuFrostMaster(RootGrid, this.Get<ILogger<DanmakuFrostMaster>>());
+            }
+
             if (_cachedDanmakus.Any())
             {
                 _danmakuController.AddDanmakuList(_cachedDanmakus);

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/DanmakuViewModel/DanmakuViewModel.Properties.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/DanmakuViewModel/DanmakuViewModel.Properties.cs
@@ -19,8 +19,8 @@ public sealed partial class DanmakuViewModel
 
     private string _aid;
     private string _cid;
-    private int _segmentIndex;
     private int _position;
+    private int _duration;
 
     [ObservableProperty]
     private bool _isShowDanmaku;

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Operations.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Operations.cs
@@ -313,7 +313,7 @@ public sealed partial class PgcPlayerPageViewModel
             var aid = _episode.GetExtensionIfNotNull<long>(EpisodeExtensionDataId.Aid).ToString();
             var cid = _episode.GetExtensionIfNotNull<long>(EpisodeExtensionDataId.Cid).ToString();
             Danmaku.ResetData(aid, cid);
-            Danmaku.Redraw(true);
+            Danmaku.LoadDanmakusCommand.Execute(duration);
         }
 
         Danmaku?.UpdatePosition(progress);

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Operations.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Operations.cs
@@ -287,6 +287,7 @@ public sealed partial class VideoPlayerPageViewModel
         if (progress < duration && progress > 1 && (Danmaku?.IsEmpty() ?? false))
         {
             Danmaku?.ResetData(_view?.Information.Identifier.Id, _part?.Identifier.Id);
+            Danmaku?.LoadDanmakusCommand.Execute(duration);
         }
 
         Danmaku?.UpdatePosition(progress);

--- a/src/Libs/Danmaku.Core/DanmakuFrostMaster.cs
+++ b/src/Libs/Danmaku.Core/DanmakuFrostMaster.cs
@@ -192,6 +192,8 @@ namespace Danmaku.Core
                             break;
                         }
                     }
+
+                    _render?.Start();
                 }
                 _lastTimeMs = targetMs;
                 _isSeeking = false;


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

过去使用分段加载，在频繁的进度跳转时很容易请求失败导致加载不出弹幕。

索性直接在视频加载时就把弹幕都加载好，也省得去计算当前分段了

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
