### PR TITLE
增加直播时使用网页播放器的选项

### DIFF
--- a/src/Desktop/BiliCopilot.UI.Models/Constants/SettingNames.cs
+++ b/src/Desktop/BiliCopilot.UI.Models/Constants/SettingNames.cs
@@ -102,4 +102,5 @@ public enum SettingNames
     IsTopNavBarShown,
     MTCBehavior,
     IsAIStreamingResponse,
+    UseWebPlayerWhenLive,
 }

--- a/src/Desktop/BiliCopilot.UI/Controls/Settings/PlayerBehaviorSettingControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Settings/PlayerBehaviorSettingControl.xaml
@@ -100,6 +100,9 @@
                     </ComboBox.ItemTemplate>
                 </ComboBox>
             </base:SettingsCard>
+            <base:SettingsCard Description="{ext:Locale Name=UseWebPlayerWhenLiveDescription}" Header="{ext:Locale Name=UseWebPlayerWhenLive}">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.UseWebPlayerWhenLive, Mode=TwoWay}" />
+            </base:SettingsCard>
             <base:SettingsCard Header="{ext:Locale Name=AutoPlayWhenLoaded}">
                 <ToggleSwitch IsOn="{x:Bind ViewModel.IsAutoPlayWhenLoaded, Mode=TwoWay}" />
             </base:SettingsCard>

--- a/src/Desktop/BiliCopilot.UI/Forms/PlayerWindow.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Forms/PlayerWindow.xaml.cs
@@ -102,7 +102,8 @@ public sealed partial class PlayerWindow : WindowBase, IPlayerHostWindow, ITipWi
     {
         Activate();
         var preferPlayer = SettingsToolkit.ReadLocalSetting(SettingNames.PlayerType, PlayerType.Island);
-        if (preferPlayer == PlayerType.Web)
+        var useWebPlayer = SettingsToolkit.ReadLocalSetting(SettingNames.UseWebPlayerWhenLive, false);
+        if (preferPlayer == PlayerType.Web || useWebPlayer)
         {
             MainFrame.Navigate(typeof(WebPlayerPage), $"https://live.bilibili.com/{room.Id}");
             return;

--- a/src/Desktop/BiliCopilot.UI/Resources/zh-Hans-CN/Resources.resw
+++ b/src/Desktop/BiliCopilot.UI/Resources/zh-Hans-CN/Resources.resw
@@ -2738,4 +2738,10 @@
   <data name="CustomMpvConfigDescription" xml:space="preserve">
     <value>MPV 用户请参考 mpv.io 的说明进行自定义配置</value>
   </data>
+  <data name="UseWebPlayerWhenLive" xml:space="preserve">
+    <value>使用网页播放器观看直播</value>
+  </data>
+  <data name="UseWebPlayerWhenLiveDescription" xml:space="preserve">
+    <value>如果本机观看直播体验不佳，请打开此选项在网页中观看</value>
+  </data>
 </root>

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Items/LiveItemViewModel/LiveItemViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Items/LiveItemViewModel/LiveItemViewModel.cs
@@ -61,7 +61,8 @@ public sealed partial class LiveItemViewModel : ViewModelBase<LiveInformation>
         }
 
         var preferPlayer = SettingsToolkit.ReadLocalSetting(SettingNames.PlayerType, PlayerType.Island);
-        if (preferPlayer == PlayerType.Web)
+        var useWebPlayer = SettingsToolkit.ReadLocalSetting(SettingNames.UseWebPlayerWhenLive, false);
+        if (preferPlayer == PlayerType.Web || useWebPlayer)
         {
             this.Get<NavigationViewModel>().NavigateToOver(typeof(WebPlayerPage), GetWebUrl());
             return;

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/SettingsPageViewModel/SettingsPageViewModel.Properties.cs
@@ -163,6 +163,9 @@ public sealed partial class SettingsPageViewModel
     [ObservableProperty]
     private List<MTCBehavior> _mTCBehaviorCollection;
 
+    [ObservableProperty]
+    private bool _useWebPlayerWhenLive;
+
     /// <summary>
     /// WebDav 配置.
     /// </summary>

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/SettingsPageViewModel/SettingsPageViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/SettingsPageViewModel/SettingsPageViewModel.cs
@@ -95,6 +95,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
 
         OpenFolderAfterDownload = SettingsToolkit.ReadLocalSetting(SettingNames.OpenFolderAfterDownload, true);
         DownloadWithDanmaku = SettingsToolkit.ReadLocalSetting(SettingNames.DownloadWithDanmaku, false);
+        UseWebPlayerWhenLive = SettingsToolkit.ReadLocalSetting(SettingNames.UseWebPlayerWhenLive, false);
 
         var copyrightTemplate = ResourceToolkit.GetLocalizedString(StringNames.Copyright);
         Copyright = string.Format(copyrightTemplate, 2024);
@@ -289,4 +290,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
 
     partial void OnIsAIStreamingResponseChanged(bool value)
         => SettingsToolkit.WriteLocalSetting(SettingNames.IsAIStreamingResponse, value);
+
+    partial void OnUseWebPlayerWhenLiveChanged(bool value)
+        => SettingsToolkit.WriteLocalSetting(SettingNames.UseWebPlayerWhenLive, value);
 }


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

对于直播卡死，闪退的问题，由于我这边无法复现，所以只能取个折中的方案。

即仅在播放直播时使用网页播放器。

事实上哔哩助理本身提供的直播间功能非常有限，用网页反而是一种比较好的方式

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
