### PR TITLE
修复标题栏动画及搜索框聚焦问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Components/AppSearchBox.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Components/AppSearchBox.xaml
@@ -101,7 +101,8 @@
                 <Flyout
                     x:Name="HotSearchFlyout"
                     Opened="OnHotSearchFlyoutOpened"
-                    Placement="BottomEdgeAlignedLeft">
+                    Placement="BottomEdgeAlignedLeft"
+                    ShouldConstrainToRootBounds="False">
                     <Flyout.FlyoutPresenterStyle>
                         <Style BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" TargetType="FlyoutPresenter">
                             <Setter Property="Padding" Value="0" />

--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.Methods.cs
@@ -64,6 +64,11 @@ public sealed partial class BiliPlayer
         {
             if (args is not null)
             {
+                if (_transportControl != null)
+                {
+                    _lastRelativeMTCPoint = args.GetCurrentPoint(_transportControl).Position;
+                }
+
                 _lastPointerPoint = args.GetCurrentPoint(_overlayContainer).Position;
             }
 
@@ -73,7 +78,12 @@ public sealed partial class BiliPlayer
                 return;
             }
 
-            var isInStayArea = _transportControlTriggerRect.Contains(_lastPointerPoint ?? new(0, 0));
+            var isInStayArea = _lastRelativeMTCPoint != null
+                && _lastRelativeMTCPoint.Value.X >= 0
+                && _lastRelativeMTCPoint.Value.Y >= 0
+                && _lastRelativeMTCPoint.Value.X <= _transportControl.ActualWidth
+                && _lastRelativeMTCPoint.Value.Y <= _transportControl.ActualHeight;
+
             var shouldShow = isInStayArea;
             if (!isInStayArea)
             {
@@ -106,6 +116,7 @@ public sealed partial class BiliPlayer
         }
 
         _transportControl.Visibility = visibility;
+        MeasureTransportTriggerRect();
     }
 
     private void OnCursorTimerTick(object? sender, object e)

--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/BiliPlayer.cs
@@ -24,6 +24,7 @@ public sealed partial class BiliPlayer : PlayerControlBase
     private bool _isCursorDisposed;
     private bool _needRemeasureSize = true;
     private Point? _lastPointerPoint;
+    private Point? _lastRelativeMTCPoint;
     private bool _isDoubleTapped;
 
     private double _manipulationDeltaX;

--- a/src/Desktop/BiliCopilot.UI/Controls/RootLayout.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/RootLayout.xaml.cs
@@ -73,6 +73,9 @@ public sealed partial class RootLayout : RootLayoutBase
             SecondaryTitleBar.Title = wPage.ViewModel.Title;
             wPage.EnterPlayerHostMode();
         }
+
+        MainTitleBar.DelayUpdateAsync();
+        SecondaryTitleBar.DelayUpdateAsync();
     }
 
     /// <summary>
@@ -86,6 +89,7 @@ public sealed partial class RootLayout : RootLayoutBase
         }
 
         MainTitleBar.Visibility = Visibility.Visible;
+
         SecondaryTitleBar.Visibility = Visibility.Collapsed;
         SecondaryTitleBar.IsBackButtonVisible = false;
         this.Get<AppViewModel>().ActivatedWindow.AppWindow.TitleBar.PreferredHeightOption = Microsoft.UI.Windowing.TitleBarHeightOption.Tall;
@@ -108,6 +112,9 @@ public sealed partial class RootLayout : RootLayoutBase
         {
             wPage.ExitPlayerHostMode();
         }
+
+        MainTitleBar.DelayUpdateAsync();
+        SecondaryTitleBar.DelayUpdateAsync();
     }
 
     /// <summary>

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
@@ -176,7 +176,6 @@ public sealed partial class VideoPlayerPageViewModel
         AvId = default;
         BvId = default;
         FavoriteFolders = default;
-        HasNextVideo = false;
         SelectedFormat = default;
     }
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #807 Close #762 

二级标题栏对主标题栏造成了遮挡，影响了拖拽区域的计算

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

也修复了一个鼠标悬停引起MTC频繁切换显隐的问题
