### PR TITLE
修复在播放列表切换时没有重载选中项和评论区的问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Player/VideoPlaylistSection.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Player/VideoPlaylistSection.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class VideoPlaylistSection : VideoPlaylistSectionBase
         var item = sender.SelectedItem as VideoItemViewModel;
         if (item is not null && ViewModel.SelectedItem != item)
         {
+            ViewModel.SelectedItem = item;
             ViewModel.Page.InitializePageCommand.Execute(new VideoSnapshot(item.Data));
         }
     }

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Methods.cs
@@ -117,7 +117,6 @@ public sealed partial class VideoPlayerPageViewModel
             return;
         }
 
-        _comments.Initialize(AvId, Richasy.BiliKernel.Models.CommentTargetType.Video, Richasy.BiliKernel.Models.CommentSortType.Hot);
         var sections = new List<IPlayerSectionDetailViewModel>
         {
             new VideoPlayerInfoSectionDetailViewModel(this),

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.cs
@@ -100,6 +100,7 @@ public sealed partial class VideoPlayerPageViewModel : PlayerPageViewModelBase
             InitializeView(view);
             var initialPart = FindInitialPart(default) ?? throw new Exception("无法找到视频的分集信息.");
             _part = initialPart;
+            _comments.Initialize(AvId, Richasy.BiliKernel.Models.CommentTargetType.Video, Richasy.BiliKernel.Models.CommentSortType.Hot);
             LoadInitialProgress();
             InitializeSections();
             InitializeLoops();


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

修复播放列表内切换视频没有重载评论区的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
