### PR TITLE
将默认状态下的快进步幅调整为0.25

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/Core/TransportControl/VideoTransportControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/TransportControl/VideoTransportControl.xaml
@@ -153,7 +153,7 @@
                                         Text="{ext:Locale Name=PlaybackRate}" />
                                     <Slider
                                         x:Name="SpeedSlider"
-                                        Width="300"
+                                        Width="360"
                                         IsThumbToolTipEnabled="True"
                                         Maximum="{x:Bind ViewModel.MaxSpeed, Mode=OneWay}"
                                         Minimum="{x:Bind ViewModel.SpeedStep, Mode=OneWay}"

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/PlayerViewModelBase/PlayerViewModelBase.cs
@@ -120,7 +120,7 @@ public abstract partial class PlayerViewModelBase : ViewModelBase
         Speed = isSpeedShare ? localSpeed : 1.0;
         var isSpeedEnhancement = SettingsToolkit.ReadLocalSetting(SettingNames.IsPlayerSpeedEnhancement, false);
         MaxSpeed = isSpeedEnhancement ? 6.0 : 3.0;
-        SpeedStep = isSpeedEnhancement ? 0.1 : 0.5;
+        SpeedStep = isSpeedEnhancement ? 0.1 : 0.25;
 
         if (_isInitialized && !_isClosed)
         {


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #919 

将默认的快进步幅从 0.5 调整为 0.25，以支持 1.25 倍速

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
- 功能
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
