### PR TITLE
修复全屏状态下的播放器白边问题

### DIFF
--- a/src/Desktop/BiliCopilot.UI/Controls/RootLayout.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/RootLayout.xaml
@@ -110,10 +110,7 @@
             MenuItemsSource="{x:Bind ViewModel.MenuItems, Mode=OneWay}"
             SelectionFollowsFocus="Disabled"
             Style="{StaticResource MainNavigationViewStyle}">
-            <Grid
-                x:Name="MainGrid"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1,1,0,0">
+            <Grid x:Name="MainGrid">
                 <Grid Visibility="{x:Bind _appViewModel.IsInitialLoading, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
                     <Frame x:Name="MainFrame" Visibility="{x:Bind ViewModel.IsOverlayOpen, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}" />
                     <Grid x:Name="OverlayGrid" Visibility="{x:Bind ViewModel.IsOverlayOpen, Mode=OneWay}">

--- a/src/Desktop/BiliCopilot.UI/Controls/RootLayout.xaml.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/RootLayout.xaml.cs
@@ -50,6 +50,7 @@ public sealed partial class RootLayout : RootLayoutBase
         SecondaryTitleBar.BackIcon = mode == PlayerDisplayMode.FullWindow ? FluentIcons.Common.Symbol.WindowAd : FluentIcons.Common.Symbol.ContractDownLeft;
         this.Get<AppViewModel>().ActivatedWindow.AppWindow.TitleBar.PreferredHeightOption = Microsoft.UI.Windowing.TitleBarHeightOption.Standard;
         NavView.IsPaneOpen = false;
+        VisualStateManager.GoToState(NavView, "PaneCollapsed", false);
         VisualStateManager.GoToState(this, nameof(PlayerState), false);
 
         if (OverlayFrame.Content is VideoPlayerPage vPage)
@@ -92,6 +93,7 @@ public sealed partial class RootLayout : RootLayoutBase
         SecondaryTitleBar.IsBackButtonVisible = false;
         this.Get<AppViewModel>().ActivatedWindow.AppWindow.TitleBar.PreferredHeightOption = Microsoft.UI.Windowing.TitleBarHeightOption.Tall;
         NavView.IsPaneOpen = true;
+        VisualStateManager.GoToState(NavView, "PaneVisible", false);
         VisualStateManager.GoToState(this, nameof(NormalState), false);
 
         if (OverlayFrame.Content is VideoPlayerPage vPage)

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/SubtitleViewModel.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/SubtitleViewModel.cs
@@ -85,7 +85,7 @@ public sealed partial class SubtitleViewModel : ViewModelBase
     /// <summary>
     /// 清除字幕.
     /// </summary>
-    public void ClearSubttile()
+    public void ClearSubtitle()
         => CurrentSubtitle = default;
 
     /// <summary>

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Operations.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/PgcPlayerPageViewModel/PgcPlayerPageViewModel.Operations.cs
@@ -357,7 +357,7 @@ public sealed partial class PgcPlayerPageViewModel
         {
             // 清除弹幕.
             Danmaku.ClearDanmaku();
-            Subtitle.ClearSubttile();
+            Subtitle.ClearSubtitle();
 
             ReportProgressCommand.Execute(Player.Duration);
 

--- a/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Operations.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/View/VideoPlayerPageViewModel/VideoPlayerPageViewModel.Operations.cs
@@ -340,7 +340,7 @@ public sealed partial class VideoPlayerPageViewModel
         {
             // 清除弹幕.
             Danmaku.ClearDanmaku();
-            Subtitle.ClearSubttile();
+            Subtitle.ClearSubtitle();
 
             ReportProgressCommand.Execute(Player.Duration);
 


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close

浅色模式下，全屏播放在左侧和顶部有白边，这个是 navigationView 没有正确切换 VisualState 导致的，手动切换一下即可

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

<!-- - Bug 修复 -->
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
