### PR TITLE
修复 AOT 遗留问题（搜索用户失败 / 原生播放器崩溃）

### DIFF
--- a/src/Desktop/BiliCopilot.UI/BiliCopilot.UI.csproj
+++ b/src/Desktop/BiliCopilot.UI/BiliCopilot.UI.csproj
@@ -1645,7 +1645,7 @@
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">False</PublishReadyToRun>
-    <PublishAot Condition="'$(Configuration)' == 'Debug'">False</PublishAot>
+    <PublishAot Condition="'$(Configuration)' == 'Debug'">True</PublishAot>
     <PublishAot Condition="'$(Configuration)' != 'Debug'">True</PublishAot>
     <ApplicationIcon>Assets\logo.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/NativePlayer.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/NativePlayer.cs
@@ -30,7 +30,9 @@ public sealed partial class NativePlayer : LayoutControlBase<NativePlayerViewMod
 
     /// <inheritdoc/>
     protected override void OnApplyTemplate()
-        => _playerElement = (MediaPlayerElement)GetTemplateChild("PlayerElement");
+    {
+        _playerElement = GetTemplateChild("PlayerElement") as MediaPlayerElement;
+    }
 
     /// <inheritdoc/>
     protected override async void OnViewModelChanged(NativePlayerViewModel? oldValue, NativePlayerViewModel? newValue)

--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/NativePlayer.cs
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/NativePlayer.cs
@@ -31,7 +31,12 @@ public sealed partial class NativePlayer : LayoutControlBase<NativePlayerViewMod
     /// <inheritdoc/>
     protected override void OnApplyTemplate()
     {
-        _playerElement = GetTemplateChild("PlayerElement") as MediaPlayerElement;
+        var rootGrid = GetTemplateChild("RootGrid") as Grid;
+        _playerElement = new MediaPlayerElement();
+        _playerElement.HorizontalAlignment = HorizontalAlignment.Stretch;
+        _playerElement.VerticalAlignment = VerticalAlignment.Stretch;
+        _playerElement.AreTransportControlsEnabled = false;
+        rootGrid.Children.Add(_playerElement);
     }
 
     /// <inheritdoc/>

--- a/src/Desktop/BiliCopilot.UI/Controls/Core/Player/PlayerResources.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Core/Player/PlayerResources.xaml
@@ -91,13 +91,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:NativePlayer">
-                    <Grid Background="Black">
-                        <MediaPlayerElement
-                            x:Name="PlayerElement"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
-                            AreTransportControlsEnabled="False" />
-                    </Grid>
+                    <Grid x:Name="RootGrid" Background="Black" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Desktop/BiliCopilot.UI/Controls/Search/UserSectionDetailControl.xaml
+++ b/src/Desktop/BiliCopilot.UI/Controls/Search/UserSectionDetailControl.xaml
@@ -18,7 +18,7 @@
                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}" Layout="{StaticResource UserLayout}">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="items:UserItemViewModel">
-                            <components:UserCardControl Style="{StaticResource DefaultUserCardStyle}" ViewModel="{x:Bind}" />
+                            <components:UserCardControl ViewModel="{x:Bind}" />
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>

--- a/src/Desktop/BiliCopilot.UI/ViewModels/Core/NativePlayerViewModel/NativePlayerViewModel.Overrides.cs
+++ b/src/Desktop/BiliCopilot.UI/ViewModels/Core/NativePlayerViewModel/NativePlayerViewModel.Overrides.cs
@@ -140,7 +140,7 @@ public sealed partial class NativePlayerViewModel
             await LoadDashVideoSourceAsync();
         }
 
-        _element.SetMediaPlayer(Player);
+        _element?.SetMediaPlayer(Player);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮，哔哩使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #983 Close #984

1. 搜索用户失败是因为引用了不存在的资源
2. 原生播放器崩溃原因很奇怪，加载资源时似乎并不能正确转换 MediaPlayerElement，解决方法是手动创建该控件

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
